### PR TITLE
Changes to fix vCard

### DIFF
--- a/src/java/davmail/exchange/ExchangeSession.java
+++ b/src/java/davmail/exchange/ExchangeSession.java
@@ -2539,7 +2539,7 @@ public abstract class ExchangeSession {
             }
 
             if (contactPhoto != null) {
-                writer.writeLine("PHOTO;BASE64;TYPE=\"" + contactPhoto.contentType + "\";ENCODING=\"b\":");
+                writer.writeLine("PHOTO;TYPE=" + contactPhoto.contentType + ";ENCODING=BASE64:");
                 writer.writeLine(contactPhoto.content, true);
             }
 

--- a/src/java/davmail/exchange/VCardWriter.java
+++ b/src/java/davmail/exchange/VCardWriter.java
@@ -71,12 +71,12 @@ public class VCardWriter extends ICSBufferedWriter {
         if (value != null) {
             for (int i = 0; i < value.length(); i++) {
                 char c = value.charAt(i);
-                if (c == ',' || c == ';') {
+                if (c == ',' || c == ';' || c == '\\') {
                     buffer.append('\\');
                 }
                 if (c == '\n') {
                     buffer.append("\\n");
-                } else {
+                } else if(c != '\r') {
                     buffer.append(value.charAt(i));
                 }
             }


### PR DESCRIPTION
Ran DavMail against a large Exchange 2013 address list with 11,086 contacts resulted in only about 5,000 contacts pulling down. Determined part of the issue was carriage returns in property values. While in the part of code that deals with that, also noticed that the escape character itself (e.g. the backslash) was not being escaped in property values. Fixed both. On next test, sync produced 10,994 contacts. Determined issue was contacts with photos and corrected that. Next sync produced all 11,086 contacts complete with photos for those that had them.