### PR TITLE
desktop file: remove deprecations and duplicate main categories

### DIFF
--- a/src/contribs/rpm/SOURCES/davmail.desktop
+++ b/src/contribs/rpm/SOURCES/davmail.desktop
@@ -6,4 +6,4 @@ Name=DavMail
 Icon=davmail
 Exec=/usr/bin/davmail
 Comment=DavMail POP/IMAP/SMTP/Caldav/Carddav/LDAP Exchange Gateway
-Categories=Network;
+Categories=GTK;GNOME;Network;

--- a/src/contribs/rpm/SOURCES/davmail.desktop
+++ b/src/contribs/rpm/SOURCES/davmail.desktop
@@ -2,9 +2,8 @@
 Version=1.0
 Type=Application
 Terminal=false
-Encoding=UTF-8
 Name=DavMail
 Icon=davmail
 Exec=/usr/bin/davmail
 Comment=DavMail POP/IMAP/SMTP/Caldav/Carddav/LDAP Exchange Gateway
-Categories=Application;Office;Email;Network;Calendar;ContactManagement;
+Categories=Network;


### PR DESCRIPTION
To satisfy desktop-file-validate

Modeled after the debian desktop file in build.xml