### PR TITLE
DesktopBrowser: add support for xdg-open directly

### DIFF
--- a/src/java/davmail/ui/browser/DesktopBrowser.java
+++ b/src/java/davmail/ui/browser/DesktopBrowser.java
@@ -68,6 +68,16 @@ public final class DesktopBrowser {
                     DavGatewayTray.error(new BundleMessage("LOG_UNABLE_TO_OPEN_LINK"), e2);
                 }
             }
+        } catch (java.lang.UnsupportedOperationException e) {
+            if (System.getProperty("os.name").toLowerCase().startsWith("linux")) {
+                try {
+                    XdgDesktopBrowser.browse(location);
+                } catch (Exception e2) {
+                    DavGatewayTray.error(new BundleMessage("LOG_UNABLE_TO_OPEN_LINK"), e2);
+                }
+            } else {
+                DavGatewayTray.error(new BundleMessage("LOG_UNABLE_TO_OPEN_LINK"), e);
+            }
         } catch (Exception e) {
             DavGatewayTray.error(new BundleMessage("LOG_UNABLE_TO_OPEN_LINK"), e);
         }

--- a/src/java/davmail/ui/browser/XdgDesktopBrowser.java
+++ b/src/java/davmail/ui/browser/XdgDesktopBrowser.java
@@ -1,0 +1,41 @@
+/*
+ * DavMail POP/IMAP/SMTP/CalDav/LDAP Exchange Gateway
+ * Copyright (C) 2009  Mickael Guessant
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package davmail.ui.browser;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Failover: Runtime.exec open URL
+ */
+public final class XdgDesktopBrowser {
+    private XdgDesktopBrowser() {
+    }
+
+    /**
+     * Open default browser at location URI.
+     * Use xdg-open to open browser url
+     *
+     * @param location location URI
+     * @throws IOException on error
+     */
+    public static void browse(URI location) throws IOException {
+        Runtime.getRuntime().exec("xdg-open " + location.toString());
+    }
+}


### PR DESCRIPTION
desktop browse functionality is disabled (not sure why) when running
in a flatpak sandbox.

Most linux distributions should support using xdg-open directly.