### PR TITLE
Improve documentation of client connection timeout

### DIFF
--- a/src/etc/davmail.properties
+++ b/src/etc/davmail.properties
@@ -35,7 +35,7 @@ davmail.noProxyFor=
 davmail.allowRemote=true
 # bind server sockets to a specific address
 davmail.bindAddress=
-# client connections SO timeout in seconds
+# client connection timeout in seconds - default 300, 0 to disable
 davmail.clientSoTimeout=
 
 # DavMail listeners SSL configuration

--- a/src/site/xdoc/faq.xml
+++ b/src/site/xdoc/faq.xml
@@ -323,6 +323,11 @@ calendar.debug.log.verbose=true]]></source>
                     Synchronization &amp; Storage options under Account Settings.
                 </p>
                 <p>
+                    <strong>Client disconnects from DavMail server after a few minutes</strong>
+                </p>
+                <p>The server sets a timeout on the socket which listens for client connections, controlled by the property <code>davmail.clientSoTimeout</code>. If there is no activity before the timeout period elapses, the connection will be closed. Setting this to <code>0</code> will disable the socket timeout.
+                </p>
+                <p>
                     <strong>Message deleted over IMAP still visible through OWA</strong>
                 </p>
                 <p>Delete action is not immediate with IMAP: you need to EXPUNGE the folder to actually

--- a/src/site/xdoc/serversetup.xml
+++ b/src/site/xdoc/serversetup.xml
@@ -73,7 +73,7 @@ davmail.noProxyFor=
 davmail.allowRemote=true
 # bind server sockets to a specific address
 davmail.bindAddress=
-# client connections SO timeout in seconds
+# client connection timeout in seconds - default 300, 0 to disable
 davmail.clientSoTimeout=
 
 # DavMail listeners SSL configuration


### PR DESCRIPTION
I've been trying out davmail and been pleased with it apart from my client (mutt) losing connection to the server all the time. I tested disabling the timeout and it does seem to fix my issue - undoing the change causes the issue to return. Please consider merging this, happy to tweak it further if you wish.