### PR TITLE
Added input names for form authentication

### DIFF
--- a/src/java/davmail/exchange/auth/ExchangeFormAuthenticator.java
+++ b/src/java/davmail/exchange/auth/ExchangeFormAuthenticator.java
@@ -68,6 +68,7 @@ public class ExchangeFormAuthenticator implements ExchangeAuthenticator {
         USER_NAME_FIELDS.add("SafeWordUser");
         USER_NAME_FIELDS.add("user_name");
         USER_NAME_FIELDS.add("login");
+        USER_NAME_FIELDS.add("UserName");
     }
 
     /**
@@ -80,6 +81,7 @@ public class ExchangeFormAuthenticator implements ExchangeAuthenticator {
         PASSWORD_FIELDS.add("pw");
         PASSWORD_FIELDS.add("basicPassword");
         PASSWORD_FIELDS.add("passwd");
+        PASSWORD_FIELDS.add("Password");
     }
 
     /**


### PR DESCRIPTION
Hello, in my company there is a custom login form for owa which has these names for inputs. Would it be ok to add them ?