### PR TITLE
Allow user agent to be configured in HttpClientAdapter.java.

### DIFF
--- a/src/java/davmail/http/HttpClientAdapter.java
+++ b/src/java/davmail/http/HttpClientAdapter.java
@@ -189,7 +189,7 @@ public class HttpClientAdapter implements Closeable {
         HttpClientBuilder clientBuilder = HttpClientBuilder.create()
                 .disableRedirectHandling()
                 .setDefaultRequestConfig(DEFAULT_REQUEST_CONFIG)
-                .setUserAgent(DavGatewayHttpClientFacade.IE_USER_AGENT)
+                .setUserAgent(DavGatewayHttpClientFacade.getUserAgent())
                 .setDefaultAuthSchemeRegistry(getAuthSchemeRegistry())
                 .setConnectionManager(connectionManager);
 


### PR DESCRIPTION
I am trying to set up DavMail for my company which recently migrated to
O365Modern authentication. I am trying with curl and both on
login.microsoftonline.com and our own internal ADFS server I observe
differences of behavior just by changing the user agent. With mine own
user agent (taken from Vivaldi browser on OSX:
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.88 Safari/537.36 Vivaldi/2.4.1488.35
) I have things working better for me:
 - microsoftonline does a correct HTTP redirect (ie HTTP code 302) to
   our internal ADFS
 - our ADFS correctly expose an HTTP 401 authentication and proposes
   NTLM auth, which we can use automatically with O365Modern mode and
   a username like my-domain-username|my-username@my.company.com