### PR TITLE
Allow to configure EWS folder fetch page size.

### DIFF
--- a/src/java/davmail/exchange/ews/EwsExchangeSession.java
+++ b/src/java/davmail/exchange/ews/EwsExchangeSession.java
@@ -709,7 +709,7 @@ public class EwsExchangeSession extends ExchangeSession {
         FindItemMethod findItemMethod;
         do {
             // search items in folder, do not retrieve all properties
-            findItemMethod = new FindItemMethod(folderQueryTraversal, BaseShape.ID_ONLY, folderId, resultCount, PAGE_SIZE);
+            findItemMethod = new FindItemMethod(folderQueryTraversal, BaseShape.ID_ONLY, folderId, resultCount, getPageSize());
             for (String attribute : attributes) {
                 findItemMethod.addAdditionalProperty(Field.get(attribute));
             }
@@ -742,7 +742,7 @@ public class EwsExchangeSession extends ExchangeSession {
             }
             resultCount = results.size();
             if (resultCount > 0 && LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Folder " + folderPath + " - Search items current count: " + resultCount + " fetchCount: " + PAGE_SIZE
+                LOGGER.debug("Folder " + folderPath + " - Search items current count: " + resultCount + " fetchCount: " + getPageSize()
                         + " highest uid: " + results.get(resultCount - 1).get(Field.get("imapUid").getResponseName())
                         + " lowest uid: " + results.get(0).get(Field.get("imapUid").getResponseName()));
             }
@@ -3245,6 +3245,10 @@ public class EwsExchangeSession extends ExchangeSession {
             value = priorityToImportanceMap.get(vTodoPriorityValue);
         }
         return value;
+    }
+
+    private static int getPageSize() {
+        return Settings.getIntProperty("davmail.folderFetchPageSize", PAGE_SIZE);
     }
 }
 


### PR DESCRIPTION
I have a mail box with more than 100 000 and it just takes too long on
connection to fetch all the message index. I wish to try using values
like 10000 (my company have a good connection, so we increase
performance by reducing the need to open new connections and transport
more data in each reply).