### PR TITLE
Fix EXDATE timezone issue

### DIFF
--- a/src/java/davmail/exchange/VCalendar.java
+++ b/src/java/davmail/exchange/VCalendar.java
@@ -267,6 +267,10 @@ public class VCalendar extends VObject {
                         if (reccurrenceId != null && reccurrenceId.getParam("TZID") != null) {
                             reccurrenceId.setParam("TZID", tzid);
                         }
+                        VProperty exDate = vObject.getProperty("EXDATE");
+                        if (exDate != null && exDate.getParam("TZID") != null) {
+                            exDate.setParam("TZID", tzid);
+                        }
                     }
                     // remove unsupported attachment reference
                     if (vObject.getProperty("ATTACH") != null) {


### PR DESCRIPTION
This fixes reported Issue 87, where EXDATEs weren't getting renamed with the correct Timezone info for CalDav on the excluded dates for recurring events