### PR TITLE
Allow user name to be specified as user@domain.com in addition to domain\user

### DIFF
--- a/src/java/davmail/imap/ImapConnection.java
+++ b/src/java/davmail/imap/ImapConnection.java
@@ -739,7 +739,11 @@ public class ImapConnection extends AbstractConnection {
         }
 
         if (tokens != null && tokens.length == 3) {
-            userName = tokens[0] + '\\' + tokens[1];
+            if (tokens[1].length() > 0) {
+                userName = tokens[0] + '\\' + tokens[1];
+            } else {
+                userName = tokens[0];
+            }
             baseMailboxPath = "/users/" + tokens[2] + '/';
         }
     }


### PR DESCRIPTION
This is to fix [issue # 90](https://github.com/mguessan/davmail/issues/90): shared mailboxes when hosted on outlook365, which don't use the domain\user syntax.

The end user can access this by specifying a username of 'user@domain.com//sharedmailbox@domain.com'.