### PR TITLE
Caldav: support context path when operating behind a reverse proxy

### DIFF
--- a/src/java/davmail/Settings.java
+++ b/src/java/davmail/Settings.java
@@ -168,6 +168,7 @@ public final class Settings {
         SETTINGS.put("davmail.sentKeepDelay", "0");
         SETTINGS.put("davmail.caldavPastDelay", "0");
         SETTINGS.put("davmail.caldavAutoSchedule", Boolean.TRUE.toString());
+        SETTINGS.put("davmail.caldavContextPath", "");
         SETTINGS.put("davmail.imapIdleDelay", "");
         SETTINGS.put("davmail.folderSizeLimit", "");
         SETTINGS.put("davmail.enableKeepAlive", Boolean.FALSE.toString());

--- a/src/java/davmailmessages.properties
+++ b/src/java/davmailmessages.properties
@@ -37,6 +37,7 @@ EXCEPTION_UNABLE_TO_UPDATE_MESSAGE=Unable to update message properties
 EXCEPTION_CONNECT=Connect exception: {0} {1}
 EXCEPTION_UNSUPPORTED_AUTHORIZATION_MODE=Unsupported authorization mode: {0}
 EXCEPTION_UNSUPPORTED_VALUE=Unsupported value: {0}
+EXCEPTION_CONTEXT_PATH_MISMATCH=Request {0} does not match context path {1}
 LOG_CLIENT_CLOSED_CONNECTION=Client closed connection
 LOG_CLOSE_CONNECTION_ON_TIMEOUT=Closing connection on timeout
 LOG_CONNECTION_CLOSED=Connection closed

--- a/src/java/davmailmessages_fr.properties
+++ b/src/java/davmailmessages_fr.properties
@@ -33,6 +33,7 @@ EXCEPTION_UNABLE_TO_UPDATE_MESSAGE=Impossible de mettre à jour les propriétés du
 EXCEPTION_CONNECT=Exception lors de la connexion : {0} {1}
 EXCEPTION_UNSUPPORTED_AUTHORIZATION_MODE=Mode d'authentification invalide : {0}
 EXCEPTION_UNSUPPORTED_VALUE=Valeur non supportée : {0}
+EXCEPTION_CONTEXT_PATH_MISMATCH=La demande {0} ne correspond pas au chemin de contexte {1}
 LOG_CLIENT_CLOSED_CONNECTION=Connection fermée par le client
 LOG_CLOSE_CONNECTION_ON_TIMEOUT=Connection fermée sur expiration
 LOG_CONNECTION_CLOSED=Connection fermée

--- a/src/java/davmailmessages_it.properties
+++ b/src/java/davmailmessages_it.properties
@@ -37,6 +37,7 @@ EXCEPTION_UNABLE_TO_UPDATE_MESSAGE=Impossibile aggiornare le proprietà dei messa
 EXCEPTION_CONNECT=Errore durante il collegamento: {0} {1}
 EXCEPTION_UNSUPPORTED_AUTHORIZATION_MODE=Autenticazione utente non valido: {0}
 EXCEPTION_UNSUPPORTED_VALUE=Valore non supportato: {0}
+EXCEPTION_CONTEXT_PATH_MISMATCH=La richiesta {0} non corrisponde al percorso di contesto {1}
 LOG_CLIENT_CLOSED_CONNECTION=Connessione chiusa dal client
 LOG_CLOSE_CONNECTION_ON_TIMEOUT=Si è verificato un timeout di connessione
 LOG_CONNECTION_CLOSED=Connessione chiusa


### PR DESCRIPTION
First of all, thank you for DavMail! I discovered it just recently and I am using it synchronize my Lightning calendar with O365.

As my DavMail instance is running behind a reverse proxy (nginx), I extended Caldav so that requests can contain a context path, e.g. `/caldav/users/me@acme.org/calendar/` instead of `/users/me@acme.org/calendar/`. The context path can be specified as the `davmail.caldavContextPath` property and defaults to an empty string.