### PR TITLE
encode uri before send

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -20,4 +20,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with ant
-      run: ant
+      run: ANT_OPTS="-Dfile.encoding=UTF-8" ant

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,0 +1,23 @@
+# This workflow will build a Java project with ant
+
+name: Java CI with ant
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with ant
+      run: ant

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -21,3 +21,13 @@ jobs:
         java-version: 1.8
     - name: Build with ant
       run: ANT_OPTS="-Dfile.encoding=UTF-8" ant
+    - name: Archive artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: dist-jar-zip-deb-exe-war
+        path: |
+          dist/*.jar
+          dist/*.zip
+          dist/*.deb
+          dist/*.exe
+          dist/*.war

--- a/src/java/davmail/exchange/auth/ExchangeFormAuthenticator.java
+++ b/src/java/davmail/exchange/auth/ExchangeFormAuthenticator.java
@@ -47,6 +47,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.UnknownHostException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -219,8 +220,9 @@ public class ExchangeFormAuthenticator implements ExchangeAuthenticator {
             if (isHttpAuthentication && !DavGatewayHttpClientFacade.hasNTLMorNegotiate(httpClient)) {
                 httpClient.getParams().setParameter(HttpClientParams.PREEMPTIVE_AUTHENTICATION, true);
             }
-
-            exchangeUri = java.net.URI.create(method.getURI().getURI());
+            String uri = method.getURI().getURI();
+            String encodedUri = URLEncoder.encode(uri, StandardCharsets.UTF_8.toString());
+            exchangeUri = java.net.URI.create(encodedUri);
             method.releaseConnection();
 
         } catch (DavMailAuthenticationException exc) {


### PR DESCRIPTION
fix for: https://sourceforge.net/p/davmail/mailman/davmail-users/thread/c2c50f73-b87e-f5e9-1f2f-eb28c9da4f04%40free.fr/
duo authentication is broken due to pipe character. Encoding uri fixes that issue. I think only query string should be encoded but the whole relative path is encoded in that patch.