### PR TITLE
list response as per rfc 6154

### DIFF
--- a/src/java/davmail/Settings.java
+++ b/src/java/davmail/Settings.java
@@ -550,6 +550,11 @@ public final class Settings {
         return value;
     }
 
+    public static synchronized String[] getListProperty(String property) {
+        String propertyValue = SETTINGS.getProperty(property);
+        return propertyValue.split(",");
+    }
+
     public static synchronized String loadRefreshToken(String username) {
         String tokenFilePath = Settings.getProperty("davmail.oauth.tokenFilePath");
         if (isEmpty(tokenFilePath)) {

--- a/src/java/davmail/exchange/ExchangeSession.java
+++ b/src/java/davmail/exchange/ExchangeSession.java
@@ -79,8 +79,9 @@ public abstract class ExchangeSession {
     protected static final String TRASH = "Trash";
     protected static final String JUNK = "Junk";
     protected static final String UNSENT = "Unsent Messages";
+    protected static final String ARCHIVE = "Archive";
 
-    protected static final List<String> SPECIAL = Arrays.asList(SENT, DRAFTS, TRASH, JUNK);
+    protected static final List<String> SPECIAL = Arrays.asList(SENT, DRAFTS, TRASH, JUNK, ARCHIVE);
 
     static {
         // Adjust Mime decoder settings

--- a/src/java/davmail/imap/ImapConnection.java
+++ b/src/java/davmail/imap/ImapConnection.java
@@ -201,6 +201,7 @@ public class ImapConnection extends AbstractConnection {
                                                 }
                                                 boolean wildcard = folderQuery.endsWith("%") && !folderQuery.contains("/") && !folderQuery.equals("%");
                                                 boolean recursive = folderQuery.endsWith("*");
+                                                specialOnly = specialOnly && !folderQuery.equals("%");
                                                 sendSubFolders(command, folderQuery.substring(0, folderQuery.length() - 1), recursive, wildcard, specialOnly);
                                                 sendClient(commandId + " OK " + command + " completed");
                                             } else {


### PR DESCRIPTION

Fixes #119
rfc 6154 specifies different behavior for "%" and "*". 
'%' - returns all mailboxes with special-use flagged.
'*' - returns only mailboxes with special-use flags (and includes the flags).
Without this patch, geary only sees the special-use mailboxes.