### PR TITLE
use custom useragent in O365Interactive web panel

### DIFF
--- a/src/java/davmail/exchange/auth/O365InteractiveAuthenticatorFrame.java
+++ b/src/java/davmail/exchange/auth/O365InteractiveAuthenticatorFrame.java
@@ -20,6 +20,7 @@
 package davmail.exchange.auth;
 
 import davmail.BundleMessage;
+import davmail.http.DavGatewayHttpClientFacade;
 import davmail.ui.tray.DavGatewayTray;
 import davmail.util.IOUtil;
 import javafx.application.Platform;
@@ -209,6 +210,8 @@ public class O365InteractiveAuthenticatorFrame extends JFrame {
         hBox.getChildren().setAll(webView, loadProgress);
         Scene scene = new Scene(hBox);
         fxPanel.setScene(scene);
+
+        webViewEngine.setUserAgent(DavGatewayHttpClientFacade.getUserAgent());
 
         webViewEngine.setOnAlert(stringWebEvent -> SwingUtilities.invokeLater(() -> {
             String message = stringWebEvent.getData();


### PR DESCRIPTION
When O365 "Conditional Access" is enabled for a tenant `davmail.mode=O365Interactive` dosen't work. Following error is returned:
```
davmail.exchange.auth.O365InteractiveAuthenticator  - Authentication failed error=access_denied&error_description=AADSTS50005%3a+User+tried+to+log+in+to+a+device+from+a+platform+(Unknown)+that%27s+currently+not+supported+through+Conditional+Access+policy.+Supported+device+platforms+are%3a+iOS%2c+Android%2c+Mac%2c+and+Windows+flavors.
```
That's because JavaFX webEngine (interactive authentication window) use wrong user-agent.
This PR enables to use user-agent defined in `davmail.userAgent` by interactive authentication.
Fixes: https://sourceforge.net/p/davmail/support-requests/377/
`davmail.userAgent=Outlook-iOS/711.3061168.prod.iphone (3.24.1)` works in my case.
