### PR TITLE
Change default davmail.url setting

### DIFF
--- a/src/etc/davmail.properties
+++ b/src/etc/davmail.properties
@@ -15,7 +15,7 @@ davmail.server=true
 # - Auto WebDav mode with EWS failover
 davmail.mode=EWS
 # base Exchange OWA or EWS url
-davmail.url=https://outlook.office365.com/EWS/Exchange.asmx
+davmail.url=https://outlook.office.com/EWS/Exchange.asmx
 
 # Listener ports
 davmail.caldavPort=1080

--- a/src/java/davmail/Settings.java
+++ b/src/java/davmail/Settings.java
@@ -52,7 +52,7 @@ import static org.apache.http.util.TextUtils.isEmpty;
  */
 public final class Settings {
 
-    public static final String O365_URL = "https://outlook.office365.com/EWS/Exchange.asmx";
+    public static final String O365_URL = "https://outlook.office.com/EWS/Exchange.asmx";
     public static final String O365 = "O365";
     public static final String O365_MODERN = "O365Modern";
     public static final String O365_INTERACTIVE = "O365Interactive";


### PR DESCRIPTION
Change the default davmail.url setting, since
https://outlook.office365.com/EWS/Exchange.asmx
is no longer working.

https://outlook.office.com/EWS/Exchange.asmx
is working fine, so change the default to that.