### PR TITLE
Caldav: escape , ; \ more consistently

### DIFF
--- a/src/java/davmail/exchange/VProperty.java
+++ b/src/java/davmail/exchange/VProperty.java
@@ -498,8 +498,8 @@ public class VProperty {
             char c = value.charAt(i);
             if (c == '\n') {
                 buffer.append("\\n");
-            } else if (MULTIVALUED_PROPERTIES.contains(key) && c == ',') {
-                buffer.append('\\').append(',');
+            } else if (c == '\\' || c == ',' || c == ';') {
+                buffer.append('\\').append(c);
             // skip carriage return
             } else if (c != '\r') {
                 buffer.append(value.charAt(i));


### PR DESCRIPTION
According to [RFC5545 3.3.11](https://www.rfc-editor.org/rfc/rfc5545#section-3.3.11), TEXT values should have all occurrences of COMMA, SEMICOLON, and BACKSLASH escaped.  The VProperty class already has a "values" list to account for multi-valued properties, so if we encounter one of these characters, it was likely meant literally.

Fixes #104, but if there are property values in which we would expect a raw comma, they will need fixing-up.