### PR TITLE
deb pkg: move JavaFX to Recommends

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -262,7 +262,8 @@
         <deb todir="dist"
              package="davmail"
              section="mail"
-             depends="openjdk-11-jre|openjdk-8-jre|openjdk-7-jre|openjdk-6-jre|oracle-java7-jre|sun-java6-jre|default-jre,libopenjfx-java,openjfx"
+             depends="openjdk-11-jre|openjdk-8-jre|openjdk-7-jre|openjdk-6-jre|oracle-java7-jre|sun-java6-jre|default-jre"              
+             recommends="libopenjfx-java,openjfx"
              suggests="libswt-gtk-4-java,libswt-cairo-gtk-4-jni,libswt-gtk2-4-jni">
             <version upstream="${release-name}"/>
             <maintainer email="mguessan@free.fr" name="Mickaël Guessant"/>


### PR DESCRIPTION
I'm running davmail on a headless Debian box, so I'd rather avoid the heavy dependency on openjfx and dependencies. This PR moves openjfx from `Required` to `Recommends` so it's installed by default (unless the user has opted out of installing recommended packages), but not required.