### PR TITLE
Changed authentication link log level

### DIFF
--- a/src/java/davmail/exchange/auth/O365Authenticator.java
+++ b/src/java/davmail/exchange/auth/O365Authenticator.java
@@ -209,8 +209,8 @@ public class O365Authenticator implements ExchangeAuthenticator {
                         // extract response
                         config = extractConfig(logonMethod.getResponseBodyAsString());
                         if (config.optJSONArray("arrScopes") != null || config.optJSONArray("urlPostRedirect") != null) {
-                            LOGGER.debug("Authentication successful but user consent or validation needed, please open the following url in a browser");
-                            LOGGER.debug(url);
+                            LOGGER.warn("Authentication successful but user consent or validation needed, please open the following url in a browser");
+                            LOGGER.warn(url);
                             throw new DavMailAuthenticationException("EXCEPTION_AUTHENTICATION_FAILED");
                         } else if (config.optString("strServiceExceptionMessage") != null) {
                             LOGGER.debug("O365 returned error: " + config.optString("strServiceExceptionMessage"));
@@ -301,8 +301,8 @@ public class O365Authenticator implements ExchangeAuthenticator {
         if (targetMethod.getStatusCode() == HttpStatus.SC_OK) {
             JSONObject config = extractConfig(responseBodyAsString);
             if (config.optJSONArray("arrScopes") != null || config.optJSONArray("urlPostRedirect") != null) {
-                LOGGER.debug("Authentication successful but user consent or validation needed, please open the following url in a browser");
-                LOGGER.debug(authorizeUrl);
+                LOGGER.warn("Authentication successful but user consent or validation needed, please open the following url in a browser");
+                LOGGER.warn(authorizeUrl);
                 throw new DavMailAuthenticationException("EXCEPTION_AUTHENTICATION_FAILED");
             }
         } else if (targetMethod.getStatusCode() != HttpStatus.SC_MOVED_TEMPORARILY || location == null) {


### PR DESCRIPTION
Changed authentication link logging statements to warn from debug so they will not be missed if the log level has not been increased.

When I was trying to get the `O365Modern` mode working I was confused because I couldn't find  the link that the document specifies should exist in the logs to complete the login process. I eventually figured out that I needed to increase the log level, but that took a while. To help others in the future I believe the URL should be visible at a lower log level.