### PR TITLE
enable ADFS authentication with SAML assertions

### DIFF
--- a/src/java/davmail/exchange/auth/ExchangeFormAuthenticator.java
+++ b/src/java/davmail/exchange/auth/ExchangeFormAuthenticator.java
@@ -376,7 +376,7 @@ public class ExchangeFormAuthenticator implements ExchangeAuthenticator {
                         }
                     }
                     // custom login form
-                    if (USER_NAME_FIELDS.contains(name)) {
+                    if (USER_NAME_FIELDS.contains(name) and !usernameInputs.contains(name)) {
                         usernameInputs.add(name);
                     } else if (PASSWORD_FIELDS.contains(name)) {
                         passwordInput = name;

--- a/src/java/davmail/exchange/auth/ExchangeFormAuthenticator.java
+++ b/src/java/davmail/exchange/auth/ExchangeFormAuthenticator.java
@@ -376,7 +376,7 @@ public class ExchangeFormAuthenticator implements ExchangeAuthenticator {
                         }
                     }
                     // custom login form
-                    if (USER_NAME_FIELDS.contains(name) and !usernameInputs.contains(name)) {
+                    if (USER_NAME_FIELDS.contains(name) && !usernameInputs.contains(name)) {
                         usernameInputs.add(name);
                     } else if (PASSWORD_FIELDS.contains(name)) {
                         passwordInput = name;


### PR DESCRIPTION
Similar to #111, ADFS support for authentication might result in weird corner cases. This PR works for the authentication flow on https://webmail.lu.se/owa/ which has a few quirks. The changes should not break existing form authentications.

For documentation reasons, I quickly summarize the key points of the auth flow.

`https://webmail.lu.se/owa/` 302 redirects to 
`https://adfs.lu.se/adfs/ls/?wa=wsignin1.0&wtrealm=https%3a%2f%2fwebmail.lu.se%2fowa%2f&wctx=rm%3d0%26id%3dpassive%26ru%3d%252fowa%252f&wct=2023-02-10T07%3a20%3a38Z`
where the `wct`parameter uses the current time, probably as a nonce.

This page has the usual login form, however the form name is `loginForm`. The action is the same url with an additional `client-request-id` attribute in the form of a uuid.
`/adfs/ls/?wa=wsignin1.0&wtrealm=https%3a%2f%2fwebmail.lu.se%2fowa%2f&wctx=rm%3d0%26id%3dpassive%26ru%3d%252fowa%252f&wct=2023-02-10T07%3a20%3a38Z&client-request-id=<uuid>`
The uuid is fixed, maybe per version.
This form post request replies with a set cookie of name `MSISAuth` and then redirects to the same url as get. On get it returns a redirect page which is a form of 3 hidden fields:
The context from the initial redirect `wctx` is `rm=0&amp;id=passive&amp;ru=%2fowa%2f`
The action `wa` is `wsignin1.0`
and 
`wresult` is `&lt;t:RequestSecurityTokenResponse xmlns:t=&quot;http://schemas.xmlsoap.org/ws/2005/02/trust&quot;>&lt;t:Lifetime>&lt;wsu:Created xmlns:wsu=&quot;http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd&quot;>2023-02-10T07:20:42.574Z&lt;/wsu:Created>&lt;wsu:Expires xmlns:wsu=&quot;http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd&quot;>2023-02-10T08:20:42.574Z&lt;/wsu:Expires>&lt;/t:Lifetime>&lt;wsp:AppliesTo xmlns:wsp=&quot;http://schemas.xmlsoap.org/ws/2004/09/policy&quot;>...`

The form is automatically submitted via javascript to `https://webmail.lu.se:443/owa/`. It is important here to include a Referer, which can be any url. To parse the `wresult` correctly, the parser must allow html like tags (>) inside a form value. To post the data programmatically, I had to replace the html escaped sequences `&lt;` to < and `&quot;` to ".
The same applies for `wctx` where `&amp;` is replaced by &.

Finally the post returns a list of cookies, namely `FedAuth, FedAuth1, TimeWindowKey, TimeWindowIV, TimeWindowSig`
which allow interaction with the owa.