### PR TITLE
Add support for retrieving user certificates

### DIFF
--- a/src/java/davmail/exchange/ExchangeSession.java
+++ b/src/java/davmail/exchange/ExchangeSession.java
@@ -2020,6 +2020,9 @@ public abstract class ExchangeSession {
                 writer.writeLine("PHOTO;TYPE=" + contactPhoto.contentType + ";ENCODING=BASE64:");
                 writer.writeLine(contactPhoto.content, true);
             }
+            
+            writer.appendProperty("KEY1;X509;ENCODING=BASE64", get("msexchangecertificate"));
+            writer.appendProperty("KEY2;X509;ENCODING=BASE64", get("usersmimecertificate"));
 
             writer.endCard();
             return writer.toString();
@@ -2798,6 +2801,10 @@ public abstract class ExchangeSession {
                 } else if ("PHOTO".equals(property.getKey())) {
                     properties.put("photo", property.getValue());
                     properties.put("haspicture", "true");
+                } else if ("KEY1".equals(property.getKey())) {
+                    properties.put("msexchangecertificate", property.getValue());
+                } else if ("KEY2".equals(property.getKey())) {
+                    properties.put("usersmimecertificate", property.getValue());
                 }
             }
             LOGGER.debug("Create or update contact " + itemName + ": " + properties);
@@ -3012,6 +3019,8 @@ public abstract class ExchangeSession {
         CONTACT_ATTRIBUTES.add("private");
         CONTACT_ATTRIBUTES.add("sensitivity");
         CONTACT_ATTRIBUTES.add("fburl");
+        CONTACT_ATTRIBUTES.add("msexchangecertificate");
+        CONTACT_ATTRIBUTES.add("usersmimecertificate");
     }
 
     protected static final Set<String> DISTRIBUTION_LIST_ATTRIBUTES = new HashSet<>();

--- a/src/java/davmail/exchange/ews/ContactDataShape.java
+++ b/src/java/davmail/exchange/ews/ContactDataShape.java
@@ -1,0 +1,34 @@
+/*
+ * DavMail POP/IMAP/SMTP/CalDav/LDAP Exchange Gateway
+ * Copyright (C) 2010  Mickael Guessant
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package davmail.exchange.ews;
+
+/**
+ * ResolveNames contact data shape.
+ */
+@SuppressWarnings({"UnusedDeclaration"})
+public class ContactDataShape extends AttributeOption {
+    private ContactDataShape(String value) {
+        super("ContactDataShape", value);
+    }
+
+    public static final ContactDataShape IdOnly = new ContactDataShape("IdOnly");
+    public static final ContactDataShape Default = new ContactDataShape("Default");
+    public static final ContactDataShape AllProperties = new ContactDataShape("AllProperties");
+
+}

--- a/src/java/davmail/exchange/ews/EwsExchangeSession.java
+++ b/src/java/davmail/exchange/ews/EwsExchangeSession.java
@@ -2975,6 +2975,8 @@ public class EwsExchangeSession extends ExchangeSession {
 
         GALFIND_ATTRIBUTE_MAP.put("homePhone", "HomePhone");
         GALFIND_ATTRIBUTE_MAP.put("pager", "Pager");
+        GALFIND_ATTRIBUTE_MAP.put("msexchangecertificate", "MSExchangeCertificate");
+        GALFIND_ATTRIBUTE_MAP.put("usersmimecertificate", "UserSMIMECertificate");
     }
 
     protected static final HashSet<String> IGNORE_ATTRIBUTE_SET = new HashSet<>();

--- a/src/java/davmail/exchange/ews/Field.java
+++ b/src/java/davmail/exchange/ews/Field.java
@@ -272,6 +272,9 @@ public final class Field {
         // attachments
         FIELD_MAP.put("attachments", new UnindexedFieldURI("item:Attachments"));
 
+        // user certificate
+        FIELD_MAP.put("msexchangecertificate", new UnindexedFieldURI("contacts:MSExchangeCertificate"));
+        FIELD_MAP.put("usersmimecertificate", new UnindexedFieldURI("contacts:UserSMIMECertificate"));
     }
 
     /**

--- a/src/java/davmail/exchange/ews/ResolveNamesMethod.java
+++ b/src/java/davmail/exchange/ews/ResolveNamesMethod.java
@@ -168,6 +168,7 @@ public class ResolveNamesMethod extends EWSMethod {
                         if (!firstValueRead) {
                             // Only first certificate value will be read
                             certificate = value;
+                            firstValueRead = true;
                         } else {
                             LOGGER.debug("ResolveNames multiple certificates found, tagLocaleName="
                                     + contextTagLocalName + " Certificate [" + value + "] ignored");


### PR DESCRIPTION
It's possible to add a public S/MIME certificate for a user to the GAL. These are used when a user wants to encrypt a mail to another user, or validate their signature. The public certificate of the recipient is required. Being able to look them up rather than engage in a manual or offline synchornisation process makes this easier, as well as fetching updated certificates when they're changed.

The bulk of this work was done by @krutelp in
https://github.com/mguessan/davmail/pull/98 I merely extended it to support the UserSMIMECertificate field in addition to the MSExchangeCertificate field.

These are both part of the EWS Contact:
https://learn.microsoft.com/en-us/dotnet/api/microsoft.exchange.webservices.data.contact?view=exchange-ews-api

I tried to do it without using ContactDataShape.AllProperties but like @krutelp couldn't find a method that would return the certificates.

I extended the ignored tags based on what was returned by our Microsoft365 instance, but not all of the fields listed under the Contact type above.

I slightly modified the original PR to use Dos line endings in ResolveNamesMethod.java so exact changes could be observed instead of the entire file being changed.

I also added the keys to the contact in ExchangeSession.java as KEY1 and KEY2.

Finally, I undid the small changes in LdapConnection.java to the isMatch() methods to have them take an ExchangeSession.Contact and put them back to Map<String, String>. This was mostly done to limit the changes in the patch to those necessary.