### PR TITLE
Bug 201: Docker support for building and running

### DIFF
--- a/src/contribs/docker/.gitignore
+++ b/src/contribs/docker/.gitignore
@@ -1,0 +1,1 @@
+davmail-compile.tar

--- a/src/contribs/docker/Dockerfile
+++ b/src/contribs/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:24.10 AS davbase
+RUN mkdir -m 1777 -p /home; chmod 1777 /home
+RUN mkdir /davmail
+RUN apt-get update && apt-get -y dist-upgrade
+RUN apt-get install -y iputils-ping iproute2 strace git x11-apps default-jre libcommons-codec-java libcommons-logging-java libhtmlcleaner-java libhttpclient-java libjackrabbit-java libjcifs-java libjettison-java libjna-java liblog4j1.2-java libmail-java libopenjfx-java  libservlet-api-java libslf4j-java libstax2-api-java libswt-cairo-gtk-4-jni libswt-gtk-4-java libwoodstox-java
+
+FROM davbase AS davbuild
+RUN apt-get install -y debhelper-compat javahelper ant ant-optional
+
+
+FROM davbase AS davupstream
+RUN apt-get install -y davmail
+
+
+FROM davbase AS davmail
+ADD davmail-compile.tar /davmail
+
+
+EXPOSE 1110 1025 1143 1080 1389
+COPY entrypoint /entrypoint
+ENTRYPOINT [ "/entrypoint" ]
+ENV XAUTHORITY=/.Xauthority
+ENV DISPLAY=:0
+VOLUME [ "/tmp/.X11-unix" ]
+VOLUME [ "/.Xauthority" ]
+VOLUME [ "/davmail.properties" ]
+VOLUME [ "/etc/passwd:/etc/passwd:ro" ]
+VOLUME [ "/etc/group:/etc/group:ro" ]

--- a/src/contribs/docker/Makefile
+++ b/src/contribs/docker/Makefile
@@ -1,0 +1,27 @@
+SUBTAG=:next
+DTARGETS=davmail$(SUBTAG) davbuild$(SUBTAG)
+LOCATION_OF_DAVMAIL_ROOT=$$PWD/../../..
+
+all: build davmail
+
+davbuild davmail davupstream davbase:
+	docker build --target $@ -t $@$(SUBTAG) .
+
+clean:
+	rm -f davmail-compile.tar *~
+	-docker rmi $(DTARGETS)
+
+build: davbuild indirect
+
+indirect: indirect_compile indirect_archive
+
+indirect_compile:
+	docker run -it --memory=1.5g --cpus .3 --rm --name davmail-build -u "$$UID" --entrypoint "" -v "${LOCATION_OF_DAVMAIL_ROOT}:/src" -w /src "davbuild$(SUBTAG)" ant -lib /usr/share/java jar
+
+indirect_archive:
+	tar -cf davmail-compile.tar -C ${LOCATION_OF_DAVMAIL_ROOT}/dist .
+
+test:
+	docker run -it --memory=1.5g --cpus .3 --network=host --rm --name davmail -v /tmp/.X11-unix:/tmp/.X11-unix -e JAVA_OPT_USER=-Dsun.java2d.uiScale=2.0 -e "DISPLAY=$${DISPLAY}" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v "$${XAUTHORITY:-$$HOME/.Xauthority}:/.Xauthority:ro" -v $$HOME/.davmail.properties.core:/davmail.properties:ro -v $$HOME/.davmail.properties.toks:/davmail.properties.tokens:rw -u "$$UID" davmail:next
+
+.PHONY: all build davmail davbuild davupstream clean indirect indirect_compile indirect_archive

--- a/src/contribs/docker/entrypoint
+++ b/src/contribs/docker/entrypoint
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# davmail.properties is in /davmail.properties
+# /home is home directory
+#
+# set memory and enable DNS expiration
+
+for f in /davmail/davmail.jar /usr/share/davmail/davmail.jar; do
+    if [ -f $f ]; then
+	DAVMAIL="$(dirname $f)";
+	# Java ignores classpath if -jar is used.
+	#: ${JAVA_OPT_JAR:=-jar $f}
+    fi
+done
+
+: ${JAVA_OPT_BASE:=-Xmx512M -Dsun.net.inetaddr.ttl=60 -Dprism.order=j2d,sw -Dprism.verbose=true}
+: ${JAVA_OPT_EXPORTS:=--add-exports java.base/sun.net.www.protocol.https=ALL-UNNAMED}
+JAVA_OPTS="$JAVA_OPT_BASE $JAVA_OPT_EXPORTS $JAVA_OPT_JAR $JAVA_OPT_USER"
+
+
+# Determined experimentally
+export CLASSPATH=/davmail/davmail.jar:/usr/share/java/commons-logging.jar:/usr/share/java/httpclient.jar:/usr/share/java/httpcore.jar:/usr/share/java/jackrabbit-webdav.jar:/usr/share/java/javafx-base.jar:/usr/share/java/javafx-controls.jar:/usr/share/java/javafx-graphics.jar:/usr/share/java/javafx-media.jar:/usr/share/java/javafx-swing.jar:/usr/share/java/javafx-web.jar:/usr/share/java/javax.mail.jar:/usr/share/java/jettison.jar:/usr/share/java/jna.jar:/usr/share/java/log4j-1.2.jar:/usr/share/java/swt4.jar:/usr/share/java/stax2-api.jar:xercesImpl.jar:woodstox-core-asl.jar:commons-codec.jar:htmlcleaner.jar:jdom2.jar:jcifs.jar
+
+export SWT_GTK3=0
+export DAVMAIL_SERVER=no
+if [ -z "$1" ]; then set -- /davmail.properties -notray; fi
+
+exec ${JAVA:-java} $JAVA_OPTS davmail.DavGateway "$@"


### PR DESCRIPTION
To actually compile, I had to make a change to build.xml (presumably because I don't know enough about java) which I did not include. Similarly, I created an "entrypoint" file which specified the CLASSPATH (and didn't use any of non-relevant code paths from the davmail shell script).

The build.xml patch is shown below:

diff --git a/build.xml b/build.xml
index d1a967c7..869f4a10 100644
--- a/build.xml
+++ b/build.xml
@@ -119,6 +119,9 @@
             <exclude name="davmail/exchange/auth/*Interactive*" unless="is.javafx"/>
             <classpath>
                 <path refid="classpath"/>
+               <fileset dir="/usr/share/java">
+                 <include name="**/*.jar" />
+               </fileset>
             </classpath>
         </javac>
     </target>