### PR TITLE
Fixed 'java.awt.AWTError: Assistive Technology not found: com.sun.java.accessibility.AccessBridge' in Windows standalone distribution

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -551,7 +551,7 @@
         <delete dir="dist/jre"/>
         <exec dir="." executable="dist/jdk/bin/jlink.exe">
             <arg value="--add-modules"/>
-            <arg value="java.base,java.datatransfer,java.desktop,java.naming,jdk.crypto.ec,java.security.jgss,java.security.sasl,java.xml,javafx.base,javafx.controls,javafx.graphics,javafx.swing,javafx.web"/>
+            <arg value="java.base,java.datatransfer,java.desktop,java.naming,jdk.crypto.ec,java.security.jgss,java.security.sasl,java.xml,javafx.base,javafx.controls,javafx.graphics,javafx.swing,javafx.web,jdk.accessibility"/>
             <arg value="--output"/>
             <arg value="dist/jre"/>
             <arg value="--strip-debug"/>


### PR DESCRIPTION
Hi,

When I tried to launch the Windows standalone (with embedded Azul JRE-FX) package for davmail 6.4.0 on my machine (Windows 11), it failed with the following error:
```
java.awt.AWTError: Assistive Technology not found: com.sun.java.accessibility.AccessBridge
        at java.desktop/java.awt.Toolkit.newAWTError(Unknown Source)
        at java.desktop/java.awt.Toolkit.fallbackToLoadClassForAT(Unknown Source)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
        at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
        at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)
        at java.desktop/java.awt.Toolkit.loadAssistiveTechnologies(Unknown Source)
        at java.desktop/java.awt.Toolkit.getDefaultToolkit(Unknown Source)
        at java.desktop/java.awt.SystemTray.isSupported(Unknown Source)
        at davmail.ui.tray.DavGatewayTray.init(DavGatewayTray.java:233)
        at davmail.DavGateway.main(DavGateway.java:108)
Caused by: java.lang.ClassNotFoundException: com.sun.java.accessibility.AccessBridge
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(Unknown Source)
        at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Unknown Source)
        at java.base/java.lang.Class.forName(Unknown Source)
        ... 15 more
```

This is caused by the absence of the `jdk.accessibility` module in the jilink custom image that's embedded in the package.
This PR addresses the issue by adding  `jdk.accessibility`  to the list of modules passed when invoking `jlink.exe` in the ` download-build-jre` ant task.

This fixes the aforementioned error, enables support for davmail for screen-readers and has a negligible impact on the overall size of the distributable package (i.e. it only add ~700kb to the zip archive).

Cheers,
Frederic

