### PR TITLE
Use sysusers.d for Fedora

### DIFF
--- a/davmail.spec
+++ b/davmail.spec
@@ -116,11 +116,6 @@ ant -Dant.java.version=1.8 prepare-dist
 %if %systemd_macros
 %if 0%{?suse_version}
 %sysusers_generate_pre %{name}-user.conf davmail %{name}-user.conf
-%else
-cat > %{name}-user.conf << @EOF
-u davmail
-g davmail
-@EOF
 %endif
 %endif
 


### PR DESCRIPTION
Currently davmail cannot be installed on Fedora 43 (which soon will be released):

```
$ podman run --rm -ti fedora:43
bash-5.3# dnf copr enable mguessan/davmail ; dnf install davmail
 https://copr.fedorainfracloud.org/api_3/rpmrepo/mguessan/davmail/fedora-43/                                          100% | 930.0   B/s | 592.0   B |  00m01s
Enabling a Copr repository. Please note that this repository is not part
of the main distribution, and quality may vary.

The Fedora Project does not exercise any power over the contents of
this repository beyond the rules outlined in the Copr FAQ at
<https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
and packages are not held to any quality or security level.

Please do not file bug reports about these packages in Fedora
Bugzilla. In case of problems, contact the owner of this repository.
Is this ok [y/N]: y
Updating and loading repositories:
 Fedora 43 openh264 (From Cisco) - x86_64                                                                             100% |   8.4 KiB/s |   5.8 KiB |  00m01s
 Copr repo for davmail owned by mguessan                                                                              100% |   6.9 KiB/s |   3.0 KiB |  00m00s
 Fedora 43 - x86_64 - Updates                                                                                         100% |  41.7 KiB/s |  27.4 KiB |  00m01s
 Fedora 43 - x86_64                                                                                                   100% |  12.7 MiB/s |  35.4 MiB |  00m03s
Repositories loaded.
Failed to resolve the transaction:
Problem: conflicting requests
  - nothing provides group(davmail) needed by davmail-6.4.0-3.1.noarch from copr:copr.fedorainfracloud.org:mguessan:davmail
  - nothing provides user(davmail) needed by davmail-6.4.0-3.1.noarch from copr:copr.fedorainfracloud.org:mguessan:davmail
You can try to add to command line:
  --skip-broken to skip uninstallable packages
```

This seems to be caused by not using sysusers.d, which was already implemented for SuSE but in a SuSE specific way.