### PR TITLE
Fedora 43 fix

### DIFF
--- a/davmail.spec
+++ b/davmail.spec
@@ -167,7 +167,7 @@ fi
 /bin/chown davmail:davmail ${file}
 /bin/chmod 0640 ${file}
 
-%if %systemd_macros
+%if %systemd_macros && 0%{?suse_version}
 %service_add_post davmail.service
 %endif
 


### PR DESCRIPTION
I got a failure when installing davmail on Fedora 43, `%service_add_post` is suse specific.