### PR TITLE
Allow messages with the same message id but different recipient list

### DIFF
--- a/src/etc/davmail.properties
+++ b/src/etc/davmail.properties
@@ -185,9 +185,6 @@ davmail.smtpSaveInSent=true
 # SMTP remove From header to force send as connected user
 #davmail.smtpStripFrom=false
 
-# SMTP allow sending multiple messages with the same message id
-#davmail.smtpAllowDuplicateSend=false
-
 #############################################################
 # Loggings settings
 

--- a/src/java/davmail/exchange/ExchangeSession.java
+++ b/src/java/davmail/exchange/ExchangeSession.java
@@ -782,6 +782,7 @@ public abstract class ExchangeSession {
     }
 
     protected String lastSentMessageId;
+    protected List<String> lastRcptToRecipients;
 
     /**
      * Send the provided message to recipients.
@@ -795,11 +796,12 @@ public abstract class ExchangeSession {
     public void sendMessage(List<String> rcptToRecipients, MimeMessage mimeMessage) throws IOException, MessagingException {
         // detect duplicate send command
         String messageId = mimeMessage.getMessageID();
-        if (lastSentMessageId != null && lastSentMessageId.equals(messageId) && Settings.getBooleanProperty("davmail.smtpAllowDuplicateSend", false)) {
+        if (lastSentMessageId != null && lastSentMessageId.equals(messageId) && lastRcptToRecipients.equals(rcptToRecipients)) {
             LOGGER.debug("Dropping message id " + messageId + ": already sent");
             return;
         }
         lastSentMessageId = messageId;
+        lastRcptToRecipients = rcptToRecipients;
 
         convertResentHeader(mimeMessage, "From");
         convertResentHeader(mimeMessage, "To");


### PR DESCRIPTION
Do not reject messages sharing message-ID with different RCPT TO addresses.

This solves #433 and #132