### PR TITLE
Fix hardcoding of used Graph endpoint URL

### DIFF
--- a/src/etc/davmail.properties
+++ b/src/etc/davmail.properties
@@ -53,6 +53,10 @@ davmail.smtpPort=1025
 # OIDC EWS scopes
 #davmail.oauth.scope=openid profile offline_access https://outlook.office365.com/EWS.AccessAsUser.All
 
+# graph
+#davmail.graphUrl=https://graph.microsoft.com
+#davmail.graphPrefix=beta
+
 # Optional: separate file to store Oauth tokens
 #davmail.oauth.tokenFilePath=
 

--- a/src/java/davmail/exchange/graph/GraphRequestBuilder.java
+++ b/src/java/davmail/exchange/graph/GraphRequestBuilder.java
@@ -51,8 +51,8 @@ public class GraphRequestBuilder {
     String method = "POST";
 
     String contentType = "application/json";
-    String baseUrl = Settings.GRAPH_URL;
-    String version = "beta";
+    String baseUrl = Settings.getGraphUrl();
+    String version = Settings.getProperty("davmail.graphPrefix", "beta");
     String mailbox;
     String objectType;
 


### PR DESCRIPTION
Fix some missed plumbing.

~Whilst doing so, allow the token refresh to support providing an `origin` header too.~