### PR TITLE
Allow sending HTTP origin header for token requests

### DIFF
--- a/src/etc/davmail.properties
+++ b/src/etc/davmail.properties
@@ -46,6 +46,9 @@ davmail.smtpPort=1025
 # On windows with SWT Webview2 embedded browser, allow using primary account single sign on
 #davmail.oauth.allowSingleSignOnUsingOSPrimaryAccount=true
 
+# Some clientId's are for Single Page Applications (SPA's) and require an HTTP 'origin' header to be sent
+#davmail.oauth.refreshTokenOrigin=https://example.com
+
 # Override OIDC scope
 # graph endpoint scopes
 #davmail.oauth.scope=openid profile offline_access Mail.ReadWrite Calendars.ReadWrite MailboxSettings.Read Mail.ReadWrite.Shared Contacts.ReadWrite Tasks.ReadWrite Mail.Send

--- a/src/java/davmail/exchange/auth/O365Token.java
+++ b/src/java/davmail/exchange/auth/O365Token.java
@@ -76,6 +76,11 @@ public class O365Token {
 
         RestRequest tokenRequest = new RestRequest(tokenUrl, new UrlEncodedFormEntity(parameters, Consts.UTF_8));
 
+        String origin = Settings.getProperty("davmail.oauth.refreshTokenOrigin");
+        if (origin != null && !origin.isEmpty()) {
+	        tokenRequest.setRequestHeader("Origin", origin);
+	}
+
         executeRequest(tokenRequest);
     }
 
@@ -221,6 +226,11 @@ public class O365Token {
         }
 
         RestRequest tokenRequest = new RestRequest(tokenUrl, new UrlEncodedFormEntity(parameters, Consts.UTF_8));
+
+        String origin = Settings.getProperty("davmail.oauth.refreshTokenOrigin");
+        if (origin != null && !origin.isEmpty()) {
+	        tokenRequest.setRequestHeader("Origin", origin);
+	}
 
         executeRequest(tokenRequest);
 


### PR DESCRIPTION
Some client ID's, in particularly Single Page Applications (SPAs), require that an HTTP `origin` header be sent to be able to exchange your code/refresh_token for an access token.

This PR allows this, discovered whilst working through #440.

To be applied after #439, this commit was originally part of that PR but it [was requested that it be broken out](https://github.com/mguessan/davmail/pull/439#issuecomment-3799537667).