### PR TITLE
Add device code authenticator

### DIFF
--- a/src/java/davmail/exchange/ExchangeSessionFactory.java
+++ b/src/java/davmail/exchange/ExchangeSessionFactory.java
@@ -172,6 +172,9 @@ public final class ExchangeSessionFactory {
                         case Settings.O365_MANUAL:
                             authenticatorClass = "davmail.exchange.auth.O365ManualAuthenticator";
                             break;
+                        case Settings.O365_DEVICECODE:
+                            authenticatorClass = "davmail.exchange.auth.O365DeviceCodeAuthenticator";
+                            break;
                     }
                 }
 


### PR DESCRIPTION
Device code authentication is a bit different from call back authentication as for device code authentication a (short) code has to be copied from davmail to the web browser.

The advantages of this are a slightly better user experience and some appid's don't allow/support call back authentication.

I think davmail could be refactored a bit to make these changes a bit more clean (make the call back url optional, make a resource a single definition, move json parsing)

Please let me know what you think of this.