### PR TITLE
Add PhoneAppOTP (TOTP) support for MFA authentication

### DIFF
--- a/src/java/davmail/exchange/auth/O365Authenticator.java
+++ b/src/java/davmail/exchange/auth/O365Authenticator.java
@@ -28,6 +28,7 @@ import davmail.http.request.PostRequest;
 import davmail.http.request.ResponseWrapper;
 import davmail.http.request.RestRequest;
 import davmail.ui.NumberMatchingFrame;
+import davmail.util.StringEncryptor;
 import davmail.ui.PasswordPromptDialog;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
@@ -35,6 +36,8 @@ import org.apache.log4j.Logger;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import javax.swing.*;
 import java.awt.*;
 import java.io.BufferedReader;
@@ -42,6 +45,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -478,6 +484,14 @@ public class O365Authenticator implements ExchangeAuthenticator {
             JSONObject authMethod = (JSONObject) config.getJSONArray("arrUserProofs").get(i);
             String authMethodId = authMethod.getString("authMethodId");
             LOGGER.debug("Authentication method: " + authMethodId);
+            if ("PhoneAppOTP".equals(authMethodId)) {
+                LOGGER.debug("Found PhoneAppOTP (TOTP) auth method " + authMethod.getString("display"));
+                isMFAMethodSupported = true;
+                chosenAuthMethodId = authMethodId;
+                chosenAuthMethodPrompt = authMethod.getString("display");
+                // prefer TOTP over all other methods
+                break;
+            }
             if ("PhoneAppNotification".equals(authMethodId)) {
                 LOGGER.debug("Found phone app auth method " + authMethod.getString("display"));
                 isMFAMethodSupported = true;
@@ -598,6 +612,10 @@ public class O365Authenticator implements ExchangeAuthenticator {
                 if ("SMSAuthFailedWrongCodeEntered".equals(resultValue)) {
                     smsCode = retrieveSmsCode(chosenAuthMethodId, chosenAuthMethodPrompt);
                 }
+                if ("PhoneAppOtpAuthFailedDuplicateCodeEntered".equals(resultValue)) {
+                    // TOTP code already used, prompt for a new one
+                    smsCode = retrieveSmsCode(chosenAuthMethodId, chosenAuthMethodPrompt);
+                }
                 if (config.getBoolean("Success")) {
                     success = true;
                 }
@@ -639,9 +657,82 @@ public class O365Authenticator implements ExchangeAuthenticator {
 
     }
 
+    private static byte[] base32Decode(String base32) {
+        String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+        base32 = base32.toUpperCase().replaceAll("[\\s=-]", "");
+        int bits = 0;
+        int value = 0;
+        int index = 0;
+        byte[] output = new byte[base32.length() * 5 / 8];
+        for (int i = 0; i < base32.length(); i++) {
+            int digit = alphabet.indexOf(base32.charAt(i));
+            if (digit < 0) continue;
+            value = (value << 5) | digit;
+            bits += 5;
+            if (bits >= 8) {
+                output[index++] = (byte) ((value >> (bits - 8)) & 0xFF);
+                bits -= 8;
+            }
+        }
+        byte[] result = new byte[index];
+        System.arraycopy(output, 0, result, 0, index);
+        return result;
+    }
+
+    private static String generateTotpCode(String base32Secret) throws IOException {
+        try {
+            byte[] key = base32Decode(base32Secret);
+            long timeStep = System.currentTimeMillis() / 1000L / 30L;
+            byte[] timeBytes = ByteBuffer.allocate(8).putLong(timeStep).array();
+
+            Mac mac = Mac.getInstance("HmacSHA1");
+            mac.init(new SecretKeySpec(key, "HmacSHA1"));
+            byte[] hash = mac.doFinal(timeBytes);
+
+            int offset = hash[hash.length - 1] & 0x0F;
+            int code = ((hash[offset] & 0x7F) << 24)
+                     | ((hash[offset + 1] & 0xFF) << 16)
+                     | ((hash[offset + 2] & 0xFF) << 8)
+                     | (hash[offset + 3] & 0xFF);
+            code = code % 1000000;
+
+            return String.format("%06d", code);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new IOException("Failed to generate TOTP code: " + e.getMessage(), e);
+        }
+    }
+
     private String retrieveSmsCode(String chosenAuthMethodId, String chosenAuthMethodPrompt) throws IOException {
         String smsCode = null;
-        if ("OneWaySMS".equals(chosenAuthMethodId)) {
+        if ("PhoneAppOTP".equals(chosenAuthMethodId)) {
+            String totpSecretProperty = "davmail.oauth.totpSecret." + username;
+            String totpSecret = Settings.getProperty(totpSecretProperty);
+            if (totpSecret == null || totpSecret.isEmpty()) {
+                totpSecretProperty = "davmail.oauth.totpSecret";
+                totpSecret = Settings.getProperty(totpSecretProperty);
+            }
+            if (totpSecret != null && !totpSecret.isEmpty()) {
+                // decrypt if encrypted, encrypt and save if plaintext
+                if (totpSecret.startsWith("{AES}")) {
+                    totpSecret = new StringEncryptor(password).decryptString(totpSecret);
+                } else {
+                    // encrypt on first use
+                    String encrypted = new StringEncryptor(password).encryptString(totpSecret);
+                    Settings.saveProperty(totpSecretProperty, encrypted);
+                    LOGGER.info("Encrypted TOTP secret for " + username);
+                }
+                smsCode = generateTotpCode(totpSecret);
+                LOGGER.info("Auto-generated TOTP code for " + username);
+            } else if (Settings.getBooleanProperty("davmail.server") || GraphicsEnvironment.isHeadless()) {
+                LOGGER.info("Need to retrieve TOTP verification code for " + username);
+                System.out.print("Enter TOTP code: ");
+                BufferedReader inReader = new BufferedReader(new InputStreamReader(System.in));
+                smsCode = inReader.readLine();
+            } else {
+                PasswordPromptDialog passwordPromptDialog = new PasswordPromptDialog("Enter TOTP code");
+                smsCode = String.valueOf(passwordPromptDialog.getPassword());
+            }
+        } else if ("OneWaySMS".equals(chosenAuthMethodId)) {
             LOGGER.info("Need to retrieve SMS verification code for " + username);
             if (Settings.getBooleanProperty("davmail.server") || GraphicsEnvironment.isHeadless()) {
                 // headless or server mode


### PR DESCRIPTION
Support PhoneAppOTP (SoftwareTokenBasedTOTP) as an MFA method in O365Authenticator, with optional automatic TOTP code generation.

EDIT: I just noticed there was an existing PR for this feature: #405.  The difference with mine is the support for multiple users/accounts.

## Changes

- Recognize PhoneAppOTP in the MFA method selection loop (highest priority)
- Handle PhoneAppOTP in retrieveSmsCode() with interactive prompt
- Handle PhoneAppOtpAuthFailedDuplicateCodeEntered in EndAuth polling loop
- Add optional davmail.oauth.totpSecret property for automatic TOTP code generation using RFC 6238 (HMAC-SHA1) with standard Java crypto (no external dependencies)

When davmail.oauth.totpSecret is set with a Base32-encoded TOTP secret, DavMail generates codes automatically, enabling fully headless daemon operation without stdin interaction. When not set, falls back to interactive prompt (stdin in server/headless mode, GUI dialog otherwise).

This fixes authentication for accounts where PhoneAppOTP is the default MFA method. Previously DavMail silently skipped it and fell back to OneWaySMS, which can be rate-limited by Microsoft (BadReputation error).

## New configuration properties

```properties
# Optional: Base32-encoded TOTP secret for automatic MFA code generation.
# When set, DavMail generates TOTP codes automatically — no manual input needed.
# When not set, DavMail prompts for the code on stdin (server/headless) or via dialog (GUI).

# Global secret (used as fallback for all users)
davmail.oauth.totpSecret=

# Per-user secrets (checked first, before the global fallback)
# davmail.oauth.totpSecret.alice@contoso.com=AAABBBCCC111222
# davmail.oauth.totpSecret.bob@contoso.com=DDDEEEFFF333444
```

Lookup order: `davmail.oauth.totpSecret.<username>` → `davmail.oauth.totpSecret` → interactive prompt.

## Usage

### Single-user setup

Add the TOTP secret to `davmail.properties`:

```properties
davmail.oauth.totpSecret=YOUR_BASE32_TOTP_SECRET
```

Start DavMail normally. When MFA is required, DavMail generates the TOTP code automatically.

### Multi-user setup

Configure per-user secrets:

```properties
davmail.oauth.totpSecret.alice@contoso.com=AAABBBCCC111222
davmail.oauth.totpSecret.bob@contoso.com=DDDEEEFFF333444
```

Each user's TOTP code is generated from their own secret. Users without a configured secret will be prompted interactively.

### TOTP secret encryption

TOTP secrets follow the same encrypt-on-first-use pattern as OAuth refresh tokens, using
the existing `StringEncryptor` class (PBE with AES-128, keyed by the user's O365 password).

On first authentication, if the TOTP secret is stored in plaintext, DavMail automatically
encrypts it and saves it back to the config file with an `{AES}` prefix:

```properties
# Before first use (plaintext):
davmail.oauth.totpSecret=XXXXXXXXXXXXXXX

# After first use (encrypted automatically):
davmail.oauth.totpSecret={AES}base64encrypteddata...
```

On subsequent authentications, the `{AES}` prefix is detected and the secret is decrypted
using the user's password before generating the TOTP code.

**Note**: The DavMail process must have write access to `davmail.properties` for
encrypt-on-first-use to work. Ensure the config file is owned by the user running DavMail.

### Interactive mode (no secret configured)

If no `totpSecret` is configured for a user, DavMail falls back to:

- **Server/headless mode**: prompts `Enter TOTP code:` on stdin
- **GUI mode**: shows a password dialog

This allows the first interactive login to cache a refresh token for subsequent daemon runs.

## Important: OAuth client ID

For headless/server deployments, you will likely need to use the Microsoft Office client
ID (`d3590ed6-52b3-4102-aeff-aad2292ab01c`) instead of DavMail's default client ID.
DavMail's built-in client ID (`facd6cff-a294-4415-b59f-c5b01937d7bd`) triggers an
Azure AD consent prompt (`arrScopes` check) that cannot be completed without a browser.
The Microsoft Office client ID is pre-consented in all Azure AD tenants and requires
the redirect URI `urn:ietf:wg:oauth:2.0:oob`:

```properties
davmail.oauth.clientId=d3590ed6-52b3-4102-aeff-aad2292ab01c
davmail.oauth.redirectUri=urn:ietf:wg:oauth:2.0:oob
```