### PR TITLE
FIX: dependency libswt-webkit-4-jni does not exist

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -291,7 +291,7 @@
         <deb todir="dist"
              package="davmail"
              section="mail"
-             depends="openjdk-21-jre|openjdk-17-jre|default-jre,libopenjfx-java,libswt-gtk-4-java,libswt-cairo-gtk-4-jni,libswt-webkit-4-jni">
+             depends="openjdk-21-jre|openjdk-17-jre|default-jre,libopenjfx-java,libswt-gtk-4-java,libswt-cairo-gtk-4-jni,libswt-webkit-gtk-4-jni">
             <version upstream="${release-name}"/>
             <maintainer email="mguessan@free.fr" name="Mickaël Guessant"/>
             <description synopsis="DavMail POP/IMAP/SMTP/Caldav/Carddav/LDAP Exchange and Office 365 Gateway">


### PR DESCRIPTION
* Fixes #465

Note: the windows-style newline bytes \x0d0a in the file are retained