### PR TITLE
Graph: send outlook.timezone Prefer header alongside IdType

### DIFF
--- a/src/java/davmail/exchange/graph/GraphRequestBuilder.java
+++ b/src/java/davmail/exchange/graph/GraphRequestBuilder.java
@@ -412,10 +412,10 @@ public class GraphRequestBuilder {
             }
 
             if (timeZone != null) {
-                httpRequest.setHeader("Prefer", "outlook.timezone=\"" + timeZone + "\"");
+                httpRequest.addHeader("Prefer", "outlook.timezone=\"" + timeZone + "\"");
             }
 
-            httpRequest.setHeader("Prefer", "IdType=\"ImmutableId\"");
+            httpRequest.addHeader("Prefer", "IdType=\"ImmutableId\"");
 
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(httpRequest.getMethod() + " " + httpRequest.getURI());


### PR DESCRIPTION
## Summary

`GraphRequestBuilder` calls `setHeader("Prefer", ...)` twice — once with `outlook.timezone="..."` (when a timezone is configured) and once unconditionally with `IdType="ImmutableId"`. Because `setHeader` replaces the header value, the timezone preference is silently overwritten and never sent to Microsoft Graph. Graph then returns event datetimes in UTC regardless of `davmail.timezoneId`, and CalDAV clients see every event labelled `TZID=UTC`.

This was reproducible on a personal Outlook.com account in `O365Interactive` mode with `enableGraph=true`, `enableEws=false`. Setting `davmail.timezoneId=W. Europe Standard Time` had no observable effect — events on the wire still came back UTC.

## Fix

Switch both `Prefer` calls to `addHeader`, so they're sent as separate header lines. Microsoft Graph then honours the `outlook.timezone` preference (RFC 7240 also allows comma-separated tokens in a single Prefer header, but multiple lines work too and keep the diff minimal).

```diff
 if (timeZone != null) {
-    httpRequest.setHeader("Prefer", "outlook.timezone=\"" + timeZone + "\"");
+    httpRequest.addHeader("Prefer", "outlook.timezone=\"" + timeZone + "\"");
 }

-httpRequest.setHeader("Prefer", "IdType=\"ImmutableId\"");
+httpRequest.addHeader("Prefer", "IdType=\"ImmutableId\"");
```

## Test plan

- [x] Verified manually on a personal Outlook.com account with `davmail.timezoneId=W. Europe Standard Time`.
  - Before: Thunderbird CalDAV `REPORT` responses for events contained `DTSTART;TZID=UTC:...`.
  - After: same events come back as `DTSTART;TZID=W. Europe Standard Time:...` and Thunderbird shows them in local time.
- [x] `IdType="ImmutableId"` preference is still sent (verified via Graph response IDs being immutable IDs as before).