### PR TITLE
Graph: Add support for numbered recurrence type in CalDAV downloads.

### DIFF
--- a/src/java/davmail/exchange/graph/GraphExchangeSession.java
+++ b/src/java/davmail/exchange/graph/GraphExchangeSession.java
@@ -393,7 +393,10 @@ public class GraphExchangeSession extends ExchangeSession {
                 if (rangeType.equals("endDate")) {
                     String endDate = buildUntilDate(range.getString("endDate"), range.getString("recurrenceTimeZone"), graphObject.optJSONObject("start"));
                     rruleValue.append(";UNTIL=").append(endDate);
-                }
+                } else if (rangeType.equals("numbered")) {
+                    int numberOfOccurrences = range.getInt("numberOfOccurrences");
+                    rruleValue.append(";COUNT=").append(Integer.toString(numberOfOccurrences));
+                } // noEnd is third option
                 if (interval > 0) {
                     rruleValue.append(";INTERVAL=").append(interval);
                 }


### PR DESCRIPTION
As described in #467, davmail was missing support for the `numbered` recurrence type. This PR adds that support.

Tested manually on a complex multi-user deployment with multiple existing numbered occurrence events. Before this PR, those events show up in CalDAV as repeating indefinitely. After, they have the proper number of recurrences.