### PR TITLE
Graph: Gracefully handle Microsoft Graph timezones different than user timezone

### DIFF
--- a/src/java/davmail/exchange/graph/GraphExchangeSession.java
+++ b/src/java/davmail/exchange/graph/GraphExchangeSession.java
@@ -1240,7 +1240,7 @@ public class GraphExchangeSession extends ExchangeSession {
             String timeZone = jsonDateTimeTimeZone.optString("timeZone");
             String dateTime = convertDateFromExchange(jsonDateTimeTimeZone.optString("dateTime"));
             // Convert from server to user timezone if different
-            if (timeZone != getVTimezone().getPropertyValue("TZID")) {
+            if (timeZone != null && !timeZone.equals(getVTimezone().getPropertyValue("TZID"))) {
                 LOGGER.debug("Server timezone different from user, doing conversion.");
                 SimpleDateFormat parser = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
                 SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd'T'HHmmss");

--- a/src/java/davmail/exchange/graph/GraphExchangeSession.java
+++ b/src/java/davmail/exchange/graph/GraphExchangeSession.java
@@ -1236,11 +1236,24 @@ public class GraphExchangeSession extends ExchangeSession {
     }
 
     private VProperty convertDateTimeTimeZoneToVproperty(String vPropertyName, JSONObject jsonDateTimeTimeZone) throws DavMailException {
-
         if (jsonDateTimeTimeZone != null) {
             String timeZone = jsonDateTimeTimeZone.optString("timeZone");
-            String dateTime = jsonDateTimeTimeZone.optString("dateTime");
-            VProperty vProperty = new VProperty(vPropertyName, convertDateFromExchange(dateTime));
+            String dateTime = convertDateFromExchange(jsonDateTimeTimeZone.optString("dateTime"));
+            // Convert from server to user timezone if different
+            if (timeZone != getVTimezone().getPropertyValue("TZID")) {
+                LOGGER.debug("Server timezone different from user, doing conversion.");
+                SimpleDateFormat parser = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
+                SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
+                parser.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(timeZone)));
+                formatter.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(getVTimezone().getPropertyValue("TZID"))));
+                try {
+                    dateTime = formatter.format(parser.parse(Character.isDigit(dateTime.charAt(dateTime.length()-1)) ? (dateTime) : (dateTime.substring(0, dateTime.length()-1))));
+                    timeZone = getVTimezone().getPropertyValue("TZID");
+                } catch (ParseException e) {
+                    LOGGER.warn("Unable to convert to user timezone: " + dateTime + ", " + timeZone + ", " + getVTimezone().getPropertyValue("TZID"));
+                }
+            }
+            VProperty vProperty = new VProperty(vPropertyName, dateTime);
             vProperty.addParam("TZID", timeZone);
             return vProperty;
         }
@@ -1261,7 +1274,6 @@ public class GraphExchangeSession extends ExchangeSession {
             zuluDateValue = dateFormat.format(exchangeDateValue);
         }
         return zuluDateValue;
-
     }
 
     protected class Contact extends ExchangeSession.Contact {


### PR DESCRIPTION
As described in #469, Microsoft Graph can return events in a timezone different than that of the user. This can happen because the user timezone is unobtainable (#468), because the preferred timezone header is not set (#476) or is ignored by the server, or because the user manually set `davmail.timezoneid` to a different, more preferred, value. 

Because of this, it is important for `convertDateTimeTimeZoneToVproperty` to consider both the desired user timezone, and the timezone returned by the server, when converting dates. To minimize the chance of problems, this conversion is only done if the returned timezone and the user timezone are different. 

Testing: Tested on a complex multiuser deployment without and with #476 applied. 