### PR TITLE
Teach fixVCalendar to convert TZIDs individually.

### DIFF
--- a/src/java/davmail/exchange/VCalendar.java
+++ b/src/java/davmail/exchange/VCalendar.java
@@ -180,7 +180,6 @@ public class VCalendar extends VObject {
         }
 
         // rename TZID for maximum iCal/iPhone compatibility
-        String tzid = null;
         if (fromServer) {
             // get current tzid
             VObject vObject = vTimezone;
@@ -241,24 +240,22 @@ public class VCalendar extends VObject {
                     if ("".equals(vObject.getPropertyValue("CLASS"))) {
                         vObject.removeProperty("CLASS");
                     }
-                    // rename TZID
-                    if (tzid != null) {
-                        VProperty dtStart = vObject.getProperty("DTSTART");
-                        if (dtStart != null && dtStart.getParam("TZID") != null) {
-                            dtStart.setParam("TZID", fixupTZID(dtStart.getParamValue("TZID")));
-                        }
-                        VProperty dtEnd = vObject.getProperty("DTEND");
-                        if (dtEnd != null && dtEnd.getParam("TZID") != null) {
-                           dtEnd.setParam("TZID", fixupTZID(dtEnd.getParamValue("TZID")));
-                        }
-                        VProperty recurrenceId = vObject.getProperty("RECURRENCE-ID");
-                        if (recurrenceId != null && recurrenceId.getParam("TZID") != null) {
-                           recurrenceId.setParam("TZID", fixupTZID(recurrenceId.getParamValue("TZID")));
-                        }
-                        VProperty exDate = vObject.getProperty("EXDATE");
-                        if (exDate != null && exDate.getParam("TZID") != null) {
-                           exDate.setParam("TZID", fixupTZID(exDate.getParamValue("TZID")));
-                        }
+                    // rename TZIDs
+                    VProperty dtStart = vObject.getProperty("DTSTART");
+                    if (dtStart != null && dtStart.getParam("TZID") != null) {
+                        dtStart.setParam("TZID", fixupTZID(dtStart.getParamValue("TZID")));
+                    }
+                    VProperty dtEnd = vObject.getProperty("DTEND");
+                    if (dtEnd != null && dtEnd.getParam("TZID") != null) {
+                        dtEnd.setParam("TZID", fixupTZID(dtEnd.getParamValue("TZID")));
+                    }
+                    VProperty recurrenceId = vObject.getProperty("RECURRENCE-ID");
+                    if (recurrenceId != null && recurrenceId.getParam("TZID") != null) {
+                        recurrenceId.setParam("TZID", fixupTZID(recurrenceId.getParamValue("TZID")));
+                    }
+                    VProperty exDate = vObject.getProperty("EXDATE");
+                    if (exDate != null && exDate.getParam("TZID") != null) {
+                        exDate.setParam("TZID", fixupTZID(exDate.getParamValue("TZID")));
                     }
                     // remove unsupported attachment reference
                     if (vObject.getProperty("ATTACH") != null) {

--- a/src/java/davmail/exchange/VCalendar.java
+++ b/src/java/davmail/exchange/VCalendar.java
@@ -186,19 +186,7 @@ public class VCalendar extends VObject {
             VObject vObject = vTimezone;
             if (vObject != null) {
                 String currentTzid = vObject.getPropertyValue("TZID");
-                // fix TZID with \n (Exchange 2010 bug)
-                if (currentTzid != null && currentTzid.endsWith("\n")) {
-                    currentTzid = currentTzid.substring(0, currentTzid.length() - 1);
-                    vObject.setPropertyValue("TZID", currentTzid);
-                }
-                if (currentTzid != null && currentTzid.indexOf(' ') >= 0) {
-                    try {
-                        tzid = ResourceBundle.getBundle("timezones").getString(currentTzid);
-                        vObject.setPropertyValue("TZID", tzid);
-                    } catch (MissingResourceException e) {
-                        LOGGER.debug("Timezone " + currentTzid + " not found in rename table");
-                    }
-                }
+                vObject.setPropertyValue("TZID", fixupTZID(currentTzid));
             }
         }
 
@@ -257,19 +245,19 @@ public class VCalendar extends VObject {
                     if (tzid != null) {
                         VProperty dtStart = vObject.getProperty("DTSTART");
                         if (dtStart != null && dtStart.getParam("TZID") != null) {
-                            dtStart.setParam("TZID", tzid);
+                            dtStart.setParam("TZID", fixupTZID(dtStart.getParamValue("TZID")));
                         }
                         VProperty dtEnd = vObject.getProperty("DTEND");
                         if (dtEnd != null && dtEnd.getParam("TZID") != null) {
-                            dtEnd.setParam("TZID", tzid);
+                           dtEnd.setParam("TZID", fixupTZID(dtEnd.getParamValue("TZID")));
                         }
                         VProperty recurrenceId = vObject.getProperty("RECURRENCE-ID");
                         if (recurrenceId != null && recurrenceId.getParam("TZID") != null) {
-                            recurrenceId.setParam("TZID", tzid);
+                           recurrenceId.setParam("TZID", fixupTZID(recurrenceId.getParamValue("TZID")));
                         }
                         VProperty exDate = vObject.getProperty("EXDATE");
                         if (exDate != null && exDate.getParam("TZID") != null) {
-                            exDate.setParam("TZID", tzid);
+                           exDate.setParam("TZID", fixupTZID(exDate.getParamValue("TZID")));
                         }
                     }
                     // remove unsupported attachment reference
@@ -322,6 +310,21 @@ public class VCalendar extends VObject {
             }
         }
 
+    }
+
+    private String fixupTZID(String currentTzid) {
+        // fix TZID with \n (Exchange 2010 bug)
+        if (currentTzid != null && currentTzid.endsWith("\n")) {
+            currentTzid = currentTzid.substring(0, currentTzid.length() - 1);
+        }
+        if (currentTzid != null && currentTzid.indexOf(' ') >= 0) {
+            try {
+                currentTzid = ResourceBundle.getBundle("timezones").getString(currentTzid);
+            } catch (MissingResourceException e) {
+                LOGGER.debug("Timezone " + currentTzid + " not found in rename table");
+            }
+        }
+        return currentTzid;
     }
 
     private void fixTimezoneToServer() {


### PR DESCRIPTION
As described in #469, Microsoft Graph can return events in a timezone different than that of the user. This revealed a related problem, namely that the timezone for individual components of an event might not match the user timezone or the event "global" timezone.

Because of this, it is important for `fixVCalendar` to convert `TZID`s on an element-by-element basis, and not just replace with the "global" value.

Testing: Tested on a complex multiuser deployment without and with #476 applied.