### PR TITLE
Graph: Fix Handling of Recurrence Timezones

### DIFF
--- a/src/java/davmail/exchange/VCalendar.java
+++ b/src/java/davmail/exchange/VCalendar.java
@@ -934,7 +934,11 @@ public class VCalendar extends VObject {
                 } else {
                     dateParser = new SimpleDateFormat("yyyyMMdd'T'HHmmss", Locale.ENGLISH);
                 }
-                dateParser.setTimeZone(timeZone);
+                if (!vcalendarDateValue.endsWith("Z")) {
+                    dateParser.setTimeZone(timeZone);
+                } else {
+                    dateParser.setTimeZone(TimeZone.getTimeZone("UTC"));
+                }
                 SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ENGLISH);
                 dateFormatter.setTimeZone(ExchangeSession.GMT_TIMEZONE);
                 zuluDateValue = dateFormatter.format(dateParser.parse(vcalendarDateValue));

--- a/src/java/davmail/exchange/graph/GraphExchangeSession.java
+++ b/src/java/davmail/exchange/graph/GraphExchangeSession.java
@@ -391,7 +391,7 @@ public class GraphExchangeSession extends ExchangeSession {
                     rruleValue.append(patternType.toUpperCase());
                 }
                 if (rangeType.equals("endDate")) {
-                    String endDate = buildUntilDate(range.getString("endDate"), range.getString("recurrenceTimeZone"), graphObject.optJSONObject("start"));
+                    String endDate = buildUntilDate(range.getString("endDate"), graphObject.optJSONObject("start")); // do not need recurrenceTimeZone since we always convert to Zulu
                     rruleValue.append(";UNTIL=").append(endDate);
                 }
                 if (interval > 0) {
@@ -424,21 +424,17 @@ public class GraphExchangeSession extends ExchangeSession {
             }
         }
 
-        private String buildUntilDate(String date, String timeZone, JSONObject startDate) throws DavMailException {
+        private String buildUntilDate(String date, JSONObject startDate) throws DavMailException {
             String result = null;
             if (date != null && date.length() == 10) {
                 String startDateTimeZone = startDate.optString("timeZone");
                 String startDateDateTime = startDate.optString("dateTime");
                 String untilDateTime = date + startDateDateTime.substring(10);
 
-                if (timeZone == null) {
-                    timeZone = startDateTimeZone;
-                }
-
                 SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
                 SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
                 formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-                parser.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(timeZone)));
+                parser.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(startDateTimeZone)));
                 try {
                     result = formatter.format(parser.parse(untilDateTime));
                 } catch (ParseException e) {
@@ -451,10 +447,12 @@ public class GraphExchangeSession extends ExchangeSession {
         private String convertOriginalStartDate(String originalStart, String originalStartTimeZone) throws DavMailException {
             String result = null;
             if (originalStart != null) {
-                SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+                // Per https://learn.microsoft.com/en-us/graph/api/resources/recurrencerange?view=graph-rest-1.0, originalStart is always in
+                // ISO8601 format, which means originalStartTimeZone is not what should be used to convert the date.
+                SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
                 SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
                 formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-                parser.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(originalStartTimeZone)));
+                //parser.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(originalStartTimeZone)));
                 try {
                     result = formatter.format(parser.parse(originalStart));
                 } catch (ParseException e) {
@@ -463,7 +461,6 @@ public class GraphExchangeSession extends ExchangeSession {
             }
             return result;
         }
-
 
         private void setAttendees(VObject vEvent, GraphObject jsonEvent) throws JSONException {
             // handle organizer

--- a/src/java/davmail/exchange/graph/GraphObject.java
+++ b/src/java/davmail/exchange/graph/GraphObject.java
@@ -302,10 +302,22 @@ public class GraphObject {
         String originalStartTimeZone = optString("originalStartTimeZone");
         String originalStart = optString("originalStart");
 
-        if (originalStartTimeZone != null && originalStart != null && originalStart.length() >= 19) {
+        if (originalStart != null) {
+            // Per https://learn.microsoft.com/en-us/graph/api/resources/recurrencerange?view=graph-rest-1.0, originalStart is always in
+            // ISO8601 format, which means originalStartTimeZone is not what should be used to convert the date.
+            SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+            //parser.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(originalStartTimeZone)));
+            try {
+                originalStart = formatter.format(parser.parse(originalStart));
+            } catch (ParseException e) {
+                throw new DavMailException("EXCEPTION_INVALID_DATE", originalStart);
+            }
             // Convert date from graph to caldav format, keep timezone information
-            VProperty recurrenceId = new VProperty("RECURRENCE-ID", DateUtil.convertDateFormat(originalStart.substring(0, 19), GRAPH_DATE_TIME, CALDAV_DATE_TIME));
+            VProperty recurrenceId = new VProperty("RECURRENCE-ID", DateUtil.convertDateFormat(originalStart.substring(0,19), GRAPH_DATE_TIME, CALDAV_DATE_TIME) + "Z");
             recurrenceId.setParam("TZID", originalStartTimeZone);
+            LOGGER.warn("getRecurrenceId: " + originalStart + ", " + originalStartTimeZone + ", " + recurrenceId);
             return recurrenceId;
         } else {
             throw new DavMailException("LOG_MESSAGE", "Missing original start date and timezone");

--- a/src/java/davmail/exchange/graph/GraphObject.java
+++ b/src/java/davmail/exchange/graph/GraphObject.java
@@ -301,6 +301,7 @@ public class GraphObject {
         // get the unmodified start date and timezone of occurrence
         String originalStartTimeZone = optString("originalStartTimeZone");
         String originalStart = optString("originalStart");
+        String append = "Z";
 
         if (originalStart != null) {
             // Per https://learn.microsoft.com/en-us/graph/api/resources/recurrencerange?view=graph-rest-1.0, originalStart is always in
@@ -308,14 +309,15 @@ public class GraphObject {
             SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
             SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
             formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-            //parser.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(originalStartTimeZone)));
             try {
                 originalStart = formatter.format(parser.parse(originalStart));
             } catch (ParseException e) {
-                throw new DavMailException("EXCEPTION_INVALID_DATE", originalStart);
+                LOGGER.warn("Invalid Recurrence Date: " + originalStart);
+                // Fall back to just using first 19 characters
+                append = "";
             }
             // Convert date from graph to caldav format, keep timezone information
-            VProperty recurrenceId = new VProperty("RECURRENCE-ID", DateUtil.convertDateFormat(originalStart.substring(0,19), GRAPH_DATE_TIME, CALDAV_DATE_TIME) + "Z");
+            VProperty recurrenceId = new VProperty("RECURRENCE-ID", DateUtil.convertDateFormat(originalStart.substring(0,19), GRAPH_DATE_TIME, CALDAV_DATE_TIME) + append);
             recurrenceId.setParam("TZID", originalStartTimeZone);
             LOGGER.warn("getRecurrenceId: " + originalStart + ", " + originalStartTimeZone + ", " + recurrenceId);
             return recurrenceId;


### PR DESCRIPTION
Despite what the name implies, `originalStart` is not necessarily in the timezone given by `originalStartTimeZone`. According to https://learn.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0 , `originalStart` is always in ISO 8601 time, and always in UTC (even if  `originalStartTimeZone` is a different timezone). 

Experimental testing shows that, with no timezone (or UTC) specified by davmail, graph might return:
```
2021-06-04T19:00:00Z, Eastern Standard Time
```
While with a timezone (e.g. "Eastern Standard Time") specified by davmail, graph might return:
```
2021-06-04T15:00:00-04:00, Eastern Standard Time
```

In other words, `originalStart` needs to be parsed as an ISO 8601 time, irrespective of the value of `originalStartTimeZone`. 

The recurrence ID should then always be written in UTC time (with `Z` at end), and conversion to Exchange Zulu time (="GMT") should respect the existence of "Z" at end of a recurrence ID time (even if the `TZID` is different).

These patches accomplish that, and complete the fixes to the issues in #469. 

Testing: Testing across ca. 10000 calendar events in a multiuser complex environment, now shows that the returned ICS files are the same independent of the timezone setting to Microsoft Graph (i.e. with and without #476 applied), with the exception of dates where the local java timezone database and Microsoft graph disagree on the start/end times of daylight savings time, in which case they differ by 1 hr. This is expected. 

However, only very light testing of handling modifying recurrences, so definitely needs more, and broader, testing on that axis.