### PR TITLE
Graph: Fix null vCalendar. 

### DIFF
--- a/src/java/davmail/exchange/graph/GraphExchangeSession.java
+++ b/src/java/davmail/exchange/graph/GraphExchangeSession.java
@@ -152,11 +152,6 @@ public class GraphExchangeSession extends ExchangeSession {
 
         protected GraphObject graphObject;
 
-        /**
-         * Preloaded content for event messages
-         */
-        protected VCalendar vCalendar;
-
         public Event(String folderPath, FolderId folderId, GraphObject graphObject) {
             this.folderPath = folderPath;
             this.folderId = folderId;
@@ -183,6 +178,11 @@ public class GraphExchangeSession extends ExchangeSession {
 
             // prefer id as itemName
             itemName = StringUtil.base64ToUrl(id) + ".EML";
+        }
+
+        public Event(String folderPath, FolderId folderId, GraphObject graphObject, VCalendar vCalendar) {
+            this(folderPath, folderId, graphObject);
+            this.vCalendar = vCalendar;
         }
 
         public Event(String folderPath, String itemName, String contentClass, String itemBody, String etag, String noneMatch) throws IOException {
@@ -3259,8 +3259,7 @@ public class GraphExchangeSession extends ExchangeSession {
                     }
                     content = getICS(new SharedByteArrayInputStream(content));
 
-                    Event event = new Event(folderPath, folderId, new GraphObject(jsonResponse));
-                    event.vCalendar = new VCalendar(content, email, getVTimezone());
+                    Event event = new Event(folderPath, folderId, new GraphObject(jsonResponse), new VCalendar(content, email, getVTimezone()));
                     eventList.add(event);
 
                 } catch (IOException | MessagingException e) {


### PR DESCRIPTION
[GraphExchangeSession](https://github.com/mguessan/davmail/blame/223ded19d7916b20ae365ffff2d065a86c9e7b5d/src/java/davmail/exchange/graph/GraphExchangeSession.java#L158) redefines `protected VCalendar vCalendar` over that defined in [ExchangeSession](https://github.com/mguessan/davmail/blob/223ded19d7916b20ae365ffff2d065a86c9e7b5d/src/java/davmail/exchange/ExchangeSession.java#L2070) . What this means is that when the Event constructor is run from GraphExchangeSession, the parent constructor in ExchangeSession that gets called does not properly populate the vCalendar variable accessible from within GraphExchangeSession (which remains null, and causes the issue described in #471). 

Fix by removing the duplicate definition, and adjusting the one location relying on the local definition for access permission to no longer require that direct access.