### PR TITLE
Fix/additional tz fixups

### DIFF
--- a/src/java/davmail/exchange/graph/GraphExchangeSession.java
+++ b/src/java/davmail/exchange/graph/GraphExchangeSession.java
@@ -460,9 +460,9 @@ public class GraphExchangeSession extends ExchangeSession {
 
         private String convertOriginalStartDate(String originalStart, String originalStartTimeZone) throws DavMailException {
             String result = originalStart;
-            // should not happen originalStart is supposed to be in UTC
+            // should not happen originalStart is supposed to be in UTC, except it is actually ISO8601
             if (originalStart != null && !originalStart.endsWith("Z")) {
-                SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+                SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
                 SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
                 formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
                 parser.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(originalStartTimeZone)));

--- a/src/java/davmail/exchange/graph/GraphExchangeSession.java
+++ b/src/java/davmail/exchange/graph/GraphExchangeSession.java
@@ -312,8 +312,8 @@ public class GraphExchangeSession extends ExchangeSession {
 
             // retrieve original start timezone to restore original timezone on recurring events across DST
             String originalStartTimeZone = jsonEvent.optString("originalStartTimeZone");
-            vEvent.addProperty(convertDateTimeTimeZoneToVproperty("DTSTART", jsonEvent.optJSONObject("start"), originalStartTimeZone));
-            vEvent.addProperty(convertDateTimeTimeZoneToVproperty("DTEND", jsonEvent.optJSONObject("end"), originalStartTimeZone));
+            vEvent.addProperty(convertDateTimeTimeZoneToVproperty("DTSTART", jsonEvent.optJSONObject("start"), getVTimezone(originalStartTimeZone).getPropertyValue("TZID")));
+            vEvent.addProperty(convertDateTimeTimeZoneToVproperty("DTEND", jsonEvent.optJSONObject("end"), getVTimezone(originalStartTimeZone).getPropertyValue("TZID")));
 
             vEvent.setPropertyValue("LOCATION", jsonEvent.optString("location", "displayName"));
             vEvent.setPropertyValue("CATEGORIES", jsonEvent.optString("categories"));

--- a/src/java/davmail/exchange/graph/GraphExchangeSession.java
+++ b/src/java/davmail/exchange/graph/GraphExchangeSession.java
@@ -3834,7 +3834,7 @@ public class GraphExchangeSession extends ExchangeSession {
         if (!"tzone://Microsoft/Custom".equals(timezoneId)) {
             try {
                 return new VObject(ResourceBundle.getBundle("vtimezones").getString(timezoneId));
-            } catch (IOException e) {
+            } catch (IOException | MissingResourceException e) {
                 LOGGER.warn("Unable to get VTIMEZONE: " + e, e);
             }
         }

--- a/src/java/davmail/exchange/graph/GraphObject.java
+++ b/src/java/davmail/exchange/graph/GraphObject.java
@@ -305,29 +305,25 @@ public class GraphObject {
         String originalStart = optString("originalStart");
 
         if (originalStartTimeZone != null && originalStart != null && originalStart.length() >= 19) {
-            if ("tzone://Microsoft/Custom".equals(originalStartTimeZone)) {
-                // custom timezone, use originalStart as is
-                return new VProperty("RECURRENCE-ID", originalStart);
-            } else {
-                String convertedOriginalStart = originalStart;
-                // Per https://learn.microsoft.com/en-us/graph/api/resources/recurrencerange?view=graph-rest-1.0,
-                // originalStart is always in ISO8601 format
-                SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
-                SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
-                parser.setTimeZone(TimeZone.getTimeZone("UTC"));
-                // format to original timezone
-                formatter.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(originalStartTimeZone)));
-                try {
-                    convertedOriginalStart = formatter.format(parser.parse(originalStart));
-                } catch (ParseException e) {
-                    LOGGER.warn("Unable to convert to original timezone: " + originalStart + ", " + originalStartTimeZone);
-                }
-
-                // Convert date from graph to caldav format, keep timezone information
-                VProperty recurrenceId = new VProperty("RECURRENCE-ID", convertedOriginalStart);
-                recurrenceId.setParam("TZID", originalStartTimeZone);
-                return recurrenceId;
+            // Default to originalstart first 19 characters without the special ones
+            String convertedOriginalStart = originalStart.substring(0,19).replace("-","").replace("T","").replace(":","");
+            // Per https://learn.microsoft.com/en-us/graph/api/resources/recurrencerange?view=graph-rest-1.0,
+            // originalStart is always in ISO8601 format
+            SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
+            parser.setTimeZone(TimeZone.getTimeZone("UTC"));
+            // format to original timezone
+            formatter.setTimeZone(TimeZone.getTimeZone(convertTimezoneFromExchange(originalStartTimeZone)));
+            try {
+                convertedOriginalStart = formatter.format(parser.parse(originalStart));
+            } catch (ParseException e) {
+                LOGGER.warn("Unable to convert to original timezone: " + originalStart + ", " + originalStartTimeZone);
             }
+
+            // Convert date from graph to caldav format, keep timezone information
+            VProperty recurrenceId = new VProperty("RECURRENCE-ID", convertedOriginalStart);
+            recurrenceId.setParam("TZID", originalStartTimeZone);
+            return recurrenceId;
         } else {
             throw new DavMailException("LOG_MESSAGE", "Missing original start date and timezone");
         }


### PR DESCRIPTION
These are the changes I need on top of rev. 4094 to avoid errors and fully fix #469 for me. Four changes:

1. Fixup `recurrenceId` to always try to convert `originalStart`, and to make sure the default removes the extraneous characters that will be present when graph returns dates with a custom zone.
2. Add catch of `MissingResourceException` to `getVTimeZone` (without this, caldav clients die due to malformed returned xml in presence of an event with an unhandled timezone).
3. Ensure same "originalstarttimezone" used for vtimezone is used for DSTART and DEND. Avoids time issues when getvtimezone takes the fallback path.
4. Adjust `convertOriginalStartDate` used for exceptionOccurrences also correctly interprets originalStart as ISO8601.
