### PR TITLE
Preserve UTC timezone when creating events with Zulu DTSTART/DTEND

### DIFF
--- a/src/java/davmail/exchange/ews/EwsExchangeSession.java
+++ b/src/java/davmail/exchange/ews/EwsExchangeSession.java
@@ -141,6 +141,24 @@ public class EwsExchangeSession extends ExchangeSession {
         // Unable to map CANCELLED: cancelled events are directly deleted on Exchange
     }
 
+    static final String UTC_TIMEZONE = "UTC";
+
+    static String resolveCalendarTimezone(VObject vEvent, String propertyName) {
+        VProperty property = vEvent.getProperty(propertyName);
+        String timezone = null;
+        if (property != null) {
+            String value = property.getValue();
+            if (value != null && value.endsWith("Z")) {
+                return UTC_TIMEZONE;
+            }
+            timezone = property.getParamValue("TZID");
+        }
+        if (timezone != null && timezone.isEmpty()) {
+            timezone = null;
+        }
+        return timezone;
+    }
+
     protected HttpClientAdapter httpClient;
 
     protected Map<String, String> folderIdMap;
@@ -1629,17 +1647,24 @@ public class EwsExchangeSession extends ExchangeSession {
                 updates.add(Field.createFieldUpdate("dtstart", convertCalendarDateToExchange(vEvent.getPropertyValue("DTSTART"))));
                 updates.add(Field.createFieldUpdate("dtend", convertCalendarDateToExchange(vEvent.getPropertyValue("DTEND"))));
                 if ("Exchange2007_SP1".equals(serverVersion)) {
-                    updates.add(Field.createFieldUpdate("meetingtimezone", vEvent.getProperty("DTSTART").getParamValue("TZID")));
+                    String meetingtimezone = resolveCalendarTimezone(vEvent, "DTSTART");
+                    if (meetingtimezone != null) {
+                        updates.add(Field.createFieldUpdate("meetingtimezone", meetingtimezone));
+                    }
                 } else {
-                    String starttimezone = vEvent.getProperty("DTSTART").getParamValue("TZID");
+                    String starttimezone = resolveCalendarTimezone(vEvent, "DTSTART");
                     String endtimezone = starttimezone;
                     if (vEvent.getProperty("DTEND") != null) {
-                        endtimezone = vEvent.getProperty("DTEND").getParamValue("TZID");
+                        endtimezone = resolveCalendarTimezone(vEvent, "DTEND");
                     }
                     // for some reason we are unable to update timezone on a shared calendar
                     if (!isShared || Settings.getBooleanProperty("davmail.caldavImpersonate", false)) {
-                        updates.add(Field.createFieldUpdate("starttimezone", starttimezone));
-                        updates.add(Field.createFieldUpdate("endtimezone", endtimezone));
+                        if (starttimezone != null) {
+                            updates.add(Field.createFieldUpdate("starttimezone", starttimezone));
+                        }
+                        if (endtimezone != null) {
+                            updates.add(Field.createFieldUpdate("endtimezone", endtimezone));
+                        }
                     }
                 }
 

--- a/src/test/davmail/exchange/ews/TestEwsExchangeSessionTimezone.java
+++ b/src/test/davmail/exchange/ews/TestEwsExchangeSessionTimezone.java
@@ -1,0 +1,84 @@
+/*
+ * DavMail POP/IMAP/SMTP/CalDav/LDAP Exchange Gateway
+ * Copyright (C) 2010  Mickael Guessant
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package davmail.exchange.ews;
+
+import davmail.exchange.VObject;
+import davmail.exchange.VProperty;
+import junit.framework.TestCase;
+
+/**
+ * EWS timezone unit tests.
+ */
+public class TestEwsExchangeSessionTimezone extends TestCase {
+    public void testResolveUtcTimezoneFromZuluDateStart() {
+        VObject vEvent = new VObject();
+        vEvent.type = "VEVENT";
+        vEvent.addProperty(new VProperty("DTSTART:20240511T160000Z"));
+
+        assertEquals("UTC", EwsExchangeSession.resolveCalendarTimezone(vEvent, "DTSTART"));
+    }
+
+    public void testResolveUtcTimezoneFromZuluDateEnd() {
+        VObject vEvent = new VObject();
+        vEvent.type = "VEVENT";
+        vEvent.addProperty(new VProperty("DTEND:20240511T200000Z"));
+
+        assertEquals("UTC", EwsExchangeSession.resolveCalendarTimezone(vEvent, "DTEND"));
+    }
+
+    public void testResolveUtcTimezoneFromZuluDateStartWithTzid() {
+        VObject vEvent = new VObject();
+        vEvent.type = "VEVENT";
+        vEvent.addProperty(new VProperty("DTSTART;TZID=Europe/Paris:20240511T160000Z"));
+
+        assertEquals("UTC", EwsExchangeSession.resolveCalendarTimezone(vEvent, "DTSTART"));
+    }
+
+    public void testResolveTimezoneKeepsTzid() {
+        VObject vEvent = new VObject();
+        vEvent.type = "VEVENT";
+        vEvent.addProperty(new VProperty("DTSTART;TZID=Europe/Paris:20240511T180000"));
+
+        assertEquals("Europe/Paris", EwsExchangeSession.resolveCalendarTimezone(vEvent, "DTSTART"));
+    }
+
+    public void testResolveTimezoneLeavesFloatingDateUnset() {
+        VObject vEvent = new VObject();
+        vEvent.type = "VEVENT";
+        vEvent.addProperty(new VProperty("DTSTART:20240511T180000"));
+
+        assertNull(EwsExchangeSession.resolveCalendarTimezone(vEvent, "DTSTART"));
+    }
+
+    public void testResolveTimezoneLeavesEmptyTzidUnset() {
+        VObject vEvent = new VObject();
+        vEvent.type = "VEVENT";
+        vEvent.addProperty(new VProperty("DTSTART;TZID=\"\":20240511T180000"));
+
+        assertNull(EwsExchangeSession.resolveCalendarTimezone(vEvent, "DTSTART"));
+    }
+
+    public void testResolveTimezoneHandlesMissingDateEnd() {
+        VObject vEvent = new VObject();
+        vEvent.type = "VEVENT";
+        vEvent.addProperty(new VProperty("DTSTART:20240511T160000Z"));
+
+        assertNull(EwsExchangeSession.resolveCalendarTimezone(vEvent, "DTEND"));
+    }
+}


### PR DESCRIPTION
## Summary

Events whose `DTSTART`/`DTEND` are in Zulu time (UTC, value ends in `Z`) with no `TZID` parameter now keep their UTC time when written to Exchange/O365 instead of being shifted into the mailbox's default timezone.

## Why this matters

When an event is copied from another calendar and pasted into a DavMail-backed calendar, the pasted ICS often carries `DTSTART`/`DTEND` directly in UTC with no `VTIMEZONE` block. In `buildFieldUpdates`, DavMail read the `TZID` parameter, found none, and pushed an empty `starttimezone`/`endtimezone` (or `meetingtimezone`) field update. O365 then fell back to the user's default timezone, shifting the event by N hours. This is the root cause described in #347.

The complication is that the client-to-server path runs `VCalendar.fixVCalendar(false)` before `buildFieldUpdates`, and `fixTzid` injects the mailbox default `TZID` onto any `DTSTART`/`DTEND` that lacks one, including Zulu values. So the Zulu case has to be detected from the property value, not the `TZID` parameter.

## Changes

- Added `resolveCalendarTimezone(VObject, propertyName)`: if the date value ends in `Z` it returns `UTC` (Zulu wins, even over an injected `TZID`); otherwise it returns the `TZID` parameter, treating an empty `TZID` as none. It is null-safe when the property is absent.
- `buildFieldUpdates` uses this helper for `starttimezone`/`endtimezone` and for `meetingtimezone` in the `Exchange2007_SP1` branch. A timezone field update is emitted only when a value resolves, so events that genuinely carry no zone information are not regressed. The existing shared-calendar guard is unchanged.

## Testing

Added `TestEwsExchangeSessionTimezone` (no network session required) covering: Zulu `DTSTART`/`DTEND` resolve to `UTC`; Zulu value with an injected `TZID` still resolves to `UTC`; a real `TZID=Europe/Paris` is preserved; floating and empty-`TZID` values resolve to none; missing `DTEND` does not NPE.

- `mvn -q -o compile` passed (OpenJDK 17).
- Ran the new test directly: `OK (7 tests)`. The repo's `src/test` tree is not wired into the Maven Surefire run, so the test was compiled and executed against `target/classes` plus the project dependency classpath.

Fixes #347

AI was used for assistance.
